### PR TITLE
cleanups & consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,35 @@
 # LuaCATS definitions for the Renoise Lua API 
 
+<img src="https://www.renoise.com/sites/default/files/renoise_logo_0.png" alt="Renoise" height="100"/>
+
 This is a [Renoise Tools API](https://github.com/renoise/xrnx) add-on for the [LuaLS Language Server](https://github.com/LuaLS/lua-language-server).
+
 
 LuaLS provides various features for Lua in code editors, such as autocompletion, type hovers, dynamic type checking, diagnostics and more via [LuaCATS](https://github.com/LuaCATS) annotations.
 
+
 ## Status
 
-This is a work in progress. Below you can see which Renoise API sections have already been converted to the LuaCATS format:
+*The definitions are usable as theyt are now, but still a work in progress.*
 
-- [x] `standard.lua` *extensions of the standard Lua API in Renoise*
-- [x] `renoise.lua` *main renoise namespace*
-- [x] `renoise/application.lua` *renoise.Application*
-- [x] `renoise/application/window.lua` *renoise.ApplicationWindow*
-- [x] `renoise/document.lua` *renoise.Document.DocumentNode*
-- [x] `renoise/document/observable.lua` *renoise.Document.Observable*
-- [x] `renoise/tool.lua` *renoise.ScriptingTool*
-- [x] `renoise/midi.lua` *renoise.Midi*
-- [x] `renoise/socket.lua` *renoise.Socket*
-- [x] `renoise/osc.lua` *renoise.OsctingTool*
-- [x] `renoise/song.lua` *renoise.Song*
-- [x] `renoise/song/sequencer.lua` *renoise.PatternSequencer*
-- [x] `renoise/song/track.lua` *renoise.Track/GroupTrack*
-- [x] `renoise/song/transport.lua` *renoise.Transport*
-- [x] `renoise/song/device.lua` *renoise.AudioDevice and renoise.DeviceParameter*
-- [x] `renoise/song/instrument.lua` *renoise.Instrument*
-- [x] `renoise/song/instrument/phrase.lua` *renoise.InstrumentPhrase*
-- [x] `renoise/song/instrument/plugin.lua` *renoise.InstrumentPluginProperties*
-- [x] `renoise/song/instrument/sample.lua` *renoise.Sample/Mapping/Buffer*
-- [x] `renoise/song/instrument/sample_modulation.lua` *renoise.SampleModulationSet/Device*
-- [x] `renoise/song/instrument/sample_device_chain.lua` *renoise.SampleDeviceChain*
-- [x] `renoise/song/instrument/macro.lua` *renoise.InstrumentMacro/Mapping*
-- [x] `renoise/song/instrument/midi_input.lua` *renoise.InstrumentMidiInputProperties*
-- [x] `renoise/song/instrument/midi_output.lua` *renoise.InstrumentMidiOutputProperties*
-- [x] `renoise/song/pattern.lua` *renoise.Pattern*
-- [x] `renoise/song/pattern/line.lua` *renoise.PatternLine/Column*
-- [x] `renoise/song/pattern/track.lua` *renoise.PatternTrack*
-- [x] `renoise/song/pattern/automation.lua` *renoise.PatternTrackAutomation*
-- [x] `renoise/song/pattern_iterator.lua` *renoise.PatternIterator*
-- [x] `renoise/view_builder.lua` *renoise.Views & Widgets*
+Please report bugs or improvements in the issues [here](https://github.com/renoise/definitions/issues) or create a merge request.
+
+### Known issues
+
+* __eq, __lt, __le meta methods can't be annotated via LuaLS at the moment. 
+They are specified in `### operators` as plain comments and should be converted as soon as LuaLS supports them.
+
+* __index meta methods currently can't be annotated via LuaLS.  
+They are currently mentioned as @operator index, but won't be picked up by the language server and should be converted as soon as LuaLS supports them.
+
+* Scripts to convert/generate a HTML doc page are missing. So no HTML version can be built from the definitions yet.
+The old conversion script won't work anymore, but maybe can be used as a template, for inspirations: 
+https://github.com/renoise/xrnx/tree/master/Xtra/HtmlGen
+
+* ViewBuilder: add/remove_notifier function parameters are not yet annotated properly
+
+* ViewBuilder: functions to create views are not yet annotated properly 
+
 
 ## Usage
 
@@ -54,7 +46,8 @@ Then clone or download a copy of this repository, and configure your workspace t
 }
 ```
 
-*Note*: the "Lua.runtime.plugin" setting only is needed in order to automatically annotate the custom `class` keyword.
+The "Lua.runtime.plugin" setting only is needed in order to automatically annotate the custom `class` keyword.
+
 
 ## Contribute
 

--- a/library/renoise.lua
+++ b/library/renoise.lua
@@ -1,11 +1,9 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----This reference lists the content of the main "renoise" namespace. All Renoise
----related functions and classes are nested in this namespace.
----
----Please read the Itroduction.md first to get an overview about the complete
----API, and scripting for Renoise in general...
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
+---Renoise in general...
 ---
 
 --------------------------------------------------------------------------------

--- a/library/renoise/application.lua
+++ b/library/renoise/application.lua
@@ -1,12 +1,8 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----This reference lists all available Lua functions and classes that control
----the Renoise application. The Application is the Lua interface to Renoise's
----main GUI and window (Application and ApplicationWindow).
----
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
 ---Renoise in general...
 ---
 

--- a/library/renoise/application.lua
+++ b/library/renoise/application.lua
@@ -41,8 +41,8 @@ renoise.Application = {}
 ---**READ-ONLY** Access to the application's window.
 ---@field window renoise.ApplicationWindow
 ---
----Get or set globally used clipboard "slots" in the application.
----@field active_clipboard_index number [1-4]
+---Range: (1 - 4) Get or set globally used clipboard "slots" in the application.
+---@field active_clipboard_index number
 
 ---### functions
 

--- a/library/renoise/application.lua
+++ b/library/renoise/application.lua
@@ -290,3 +290,25 @@ function renoise.Application:save_instrument_sample(filename) end
 ---@param filename string
 ---@return boolean success
 function renoise.Application:save_theme(filename) end
+
+--------------------------------------------------------------------------------
+---## renoise.Dialog
+
+---A custom dialog created via the scripting API. Dialogs can be created
+---via `renoise.app():show_custom_dialog`.
+---
+---See `create custom views` on top of the renoise.ViewBuilder docs on how to
+---create views for the dialog.
+---@class renoise.Dialog
+---
+--- **READ-ONLY** Check if a dialog is alive and visible.
+---@field visible boolean
+renoise.Dialog = {}
+
+---### functions
+
+-- Bring an already visible dialog to front and make it the key window.
+function renoise.Dialog:show() end
+
+-- Close a visible dialog.
+function renoise.Dialog:close() end

--- a/library/renoise/application/window.lua
+++ b/library/renoise/application/window.lua
@@ -1,11 +1,8 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----This reference lists all available Lua functions and classes that control
----the Renoise application window. 
----
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for 
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
 ---Renoise in general...
 ---
 

--- a/library/renoise/document.lua
+++ b/library/renoise/document.lua
@@ -1,10 +1,8 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----This reference lists Lua functions to create custom observable documents.
----
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
 ---Renoise in general...
 ---
 
@@ -112,7 +110,7 @@ renoise.Document = {}
 ---model will fail) and to generally specify the "type".
 ---
 ---Additionally, once "create" is called, you can use the specified model name to
----create new instances. 
+---create new instances.
 ---
 ---### example:
 ---```lua

--- a/library/renoise/document/observable.lua
+++ b/library/renoise/document/observable.lua
@@ -1,11 +1,8 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----This reference lists Lua functions to access observables, a notification system
----for value changes in the Renoise API.
----
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for 
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
 ---Renoise in general...
 ---
 
@@ -21,8 +18,8 @@
 ---API is an Observer, which listens to observable values in Documents.
 ---
 ---Attaching and removing notifiers can be done with the functions 'add_notifier',
----'remove_notifier' from the renoise.Document.Observable class. These support 
----multiple kinds of callbacks, plain functions and methods (functions with a context). 
+---'remove_notifier' from the renoise.Document.Observable class. These support
+---multiple kinds of callbacks, plain functions and methods (functions with a context).
 ---
 ---### example:
 ---```lua
@@ -60,11 +57,11 @@ renoise.Document.Observable = {}
 function renoise.Document.Observable:has_notifier(notifier) end
 
 ---Register a function or method as a notifier, which will be called as soon as
----the observable's value changed. The passed notifier can either be a function 
----or a table with a function and some context (an "object") -> method. 
+---the observable's value changed. The passed notifier can either be a function
+---or a table with a function and some context (an "object") -> method.
 ---### example:
 ---```lua
----renoise.song().transport.bpm_observable:add_notifier(function() 
+---renoise.song().transport.bpm_observable:add_notifier(function()
 ---  print("BPM changed")
 ---end)
 ---
@@ -73,7 +70,7 @@ function renoise.Document.Observable:has_notifier(notifier) end
 ---  my_context,
 ---  function(context)
 ---    context.bpm_changes = context.bpm_changes + 1;
----    print(("#BPM changes: %s"):format(context.bpm_changes)); 
+---    print(("#BPM changes: %s"):format(context.bpm_changes));
 ---  end
 ---})
 ---```
@@ -83,10 +80,10 @@ function renoise.Document.Observable:has_notifier(notifier) end
 function renoise.Document.Observable:add_notifier(notifier) end
 
 ---Unregister a previously registered notifier. When only passing an object,
----all notifier functions that match the given object will be removed. 
+---all notifier functions that match the given object will be removed.
 ---This will not fire errors when no methods for the given object are attached.
----Trying to unregister a function or method which wasn't registered, will resolve 
----into an error. 
+---Trying to unregister a function or method which wasn't registered, will resolve
+---into an error.
 ---@param notifier NotifierFunction|NotifierMemberContext
 ---@overload fun(self, notifer_method: NotifierMethod1)
 ---@overload fun(self, notifer_method: NotifierMethod2)
@@ -95,7 +92,7 @@ function renoise.Document.Observable:remove_notifier(notifier) end
 --------------------------------------------------------------------------------
 ---## renoise.Document.Serializable
 
----@class renoise.Document.Serializable 
+---@class renoise.Document.Serializable
 renoise.Document.Serializable = {}
 
 ---### functions
@@ -128,7 +125,7 @@ function renoise.Document.ObservableBang:bang() end
 
 ---@class renoise.Document.ObservableBoolean : renoise.Document.Observable, renoise.Document.Serializable
 ---Read/write access to the value of an observable.
----@field value boolean 
+---@field value boolean
 ---Construct a new observable boolean.
 ---@overload fun(boolean?):renoise.Document.ObservableBoolean
 renoise.Document.ObservableBoolean = {}
@@ -210,8 +207,8 @@ function renoise.Document.ObservableList:size() end
 function renoise.Document.ObservableList:has_notifier(notifier) end
 
 ---Register a function or method as a notifier, which will be called as soon as
----the observable lists layout changed. The passed notifier can either be a function 
----or a table with a function and some context (an "object") -> method. 
+---the observable lists layout changed. The passed notifier can either be a function
+---or a table with a function and some context (an "object") -> method.
 ---@param notifier ListNotifierFunction
 ---@overload fun(self, notifer_method: ListNotifierMethod1)
 ---@overload fun(self, notifer_method: ListNotifierMethod2)
@@ -220,8 +217,8 @@ function renoise.Document.ObservableList:add_notifier(notifier) end
 ---Unregister a previously registered list notifier. When only passing an object,
 ---all notifier functions that match the given object will be removed.
 ---This will not fire errors when no methods for the given object are attached.
----Trying to unregister a function or method which wasn't registered, will resolve 
----into an error. 
+---Trying to unregister a function or method which wasn't registered, will resolve
+---into an error.
 ---@param notifier ListNotifierFunction|ListNotifierMemberContext
 ---@overload fun(self, notifer_method: ListNotifierMethod1)
 ---@overload fun(self, notifer_method: ListNotifierMethod2)

--- a/library/renoise/midi.lua
+++ b/library/renoise/midi.lua
@@ -1,11 +1,8 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----This reference describes the raw MIDI IO support for scripts in Renoise; the
----ability to send and receive MIDI data.
----
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for 
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
 ---Renoise in general...
 ---
 ---For some simple examples on how to use MIDI IO in Renoise, have a look at the
@@ -15,7 +12,7 @@
 --------------------------------------------------------------------------------
 ---## renoise.Midi
 
----Raw MIDI IO support for scripts in Renoise; the ability to send and receive 
+---Raw MIDI IO support for scripts in Renoise; the ability to send and receive
 ---MIDI data.
 renoise.Midi = {}
 

--- a/library/renoise/osc.lua
+++ b/library/renoise/osc.lua
@@ -1,25 +1,20 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----This reference describes the built-in OSC (Open Sound Control) support for
----Lua scripts in Renoise. OSC can be used in combination with sockets to
----send/receive OSC tagged data over process boundaries, or to exchange data
----across computers in a network (Internet).
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
+---Renoise in general...
 ---
 ---Have a look at http://opensoundcontrol.org for general info about OSC.
 ---
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for 
----Renoise in general...
----
 ---For some small examples on how to use the OSC and Sockets API, have a
--- look at the code snippets in the Renoise Documentation "Snippets/Osc.lua".
+---look at the code snippets in the Renoise Documentation "Snippets/Osc.lua".
 ---
 
 --------------------------------------------------------------------------------
 ---## renoise.Osc
 
----OSC (Open Sound Control) support for Lua scripts in Renoise. 
+---OSC (Open Sound Control) support for Lua scripts in Renoise.
 renoise.Osc = {}
 
 ---De-packetizing raw (socket) data to OSC messages or bundles:
@@ -60,11 +55,11 @@ renoise.Osc.Message = {}
 ---```lua
 ---> { tag="X", value=SomeValue }
 ---```
----`tag` is a standard OSC type tag. `value` is the arguments value expressed 
----by a Lua type. The value must be convertible to the specified tag, which 
----means, you cannot for example specify an "i" (integer) as type and then pass 
----a string as the value. Use a number value instead. Not all tags require a 
----value, like the T,F boolean tags. Then a `value` field should not be 
+---`tag` is a standard OSC type tag. `value` is the arguments value expressed
+---by a Lua type. The value must be convertible to the specified tag, which
+---means, you cannot for example specify an "i" (integer) as type and then pass
+---a string as the value. Use a number value instead. Not all tags require a
+---value, like the T,F boolean tags. Then a `value` field should not be
 ---specified. For more info, see: http://opensoundcontrol.org/spec-1_0
 ---
 ---Valid tags are {OSC Type Tag, Type of corresponding value}

--- a/library/renoise/socket.lua
+++ b/library/renoise/socket.lua
@@ -1,18 +1,13 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----This reference describes the built-in socket support for Lua scripts in
----Renoise. Sockets can be used to send/receive data over process boundaries,
----or exchange data across computers in a network (Internet). The socket API
----in Renoise has server support (which can respond to multiple connected clients)
----and client support (send/receive data to/from a server).
----
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for 
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
 ---Renoise in general...
 ---
 ---For examples on how to use sockets, have across look at the code snippets in
 ---the Renoise Documentation "Snippets/Socket.lua"
+---
 
 --------------------------------------------------------------------------------
 ---## renoise.Socket
@@ -83,7 +78,7 @@ function renoise.Socket.create_client(server_address, server_port, protocol, tim
 ---SocketBase properties and functions are available for servers and clients.
 ---@class renoise.Socket.SocketBase
 ---
----**READ-ONLY** Returns true when the socket object is valid and connected. 
+---**READ-ONLY** Returns true when the socket object is valid and connected.
 ---Sockets can manually be closed (see socket:close()). Client sockets can also
 ---actively be closed/refused by the server. In this case the client:receive()
 ---calls will fail and return an error.
@@ -127,7 +122,7 @@ function renoise.Socket.SocketBase:close() end
 ---is connected to.
 ---@field peer_address string
 ---
----**READ-ONLY** Port of the socket's peer, the socket this client is 
+---**READ-ONLY** Port of the socket's peer, the socket this client is
 ---connected to.
 ---@field peer_port number
 renoise.Socket.SocketClient = {}

--- a/library/renoise/song.lua
+++ b/library/renoise/song.lua
@@ -105,8 +105,8 @@ renoise.Song = {
 ---**READ-ONLY** See renoise.Song:render(). Returns true while rendering is
 ---in progress.
 ---@field rendering boolean
----**READ-ONLY** See renoise.Song:render(). Returns the current render progress
----amount [0.0-1.0]
+---**READ-ONLY** Range: (0.0 - 1.0) See renoise.Song:render(). 
+---Returns the current render progress amount 
 ---@field rendering_progress number
 ---
 ---**READ-ONLY** See renoise.Transport for more info.

--- a/library/renoise/song.lua
+++ b/library/renoise/song.lua
@@ -1,12 +1,8 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----This reference lists all available Lua functions and classes that control
----Renoise's main document - the song - and the corresponding components such as
----Instruments, Tracks, Patterns, and so on.
----
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
 ---Renoise in general...
 ---
 
@@ -261,12 +257,14 @@ renoise.Song = {
 ---Test if something in the song can be undone.
 ---@return boolean
 function renoise.Song:can_undo() end
+
 ---Undo the last performed action. Will do nothing if nothing can be undone.
 function renoise.Song:undo() end
 
 ---Test if something in the song can be redone.
 ---@return boolean
 function renoise.Song:can_redo() end
+
 ---Redo a previously undo action. Will do nothing if nothing can be redone.
 function renoise.Song:redo() end
 
@@ -309,6 +307,7 @@ function renoise.Song:track(index) end
 ---Set the selected track to prev relative to the current track. Takes
 ---care of skipping over hidden tracks and wrapping around at the edges.
 function renoise.Song:select_previous_track() end
+
 ---Set the selected track to next relative to the current track. Takes
 ---care of skipping over hidden tracks and wrapping around at the edges.
 function renoise.Song:select_next_track() end

--- a/library/renoise/song/device.lua
+++ b/library/renoise/song/device.lua
@@ -1,11 +1,8 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----This reference lists all available Lua functions and classes that control
----Renoise's audio effect documents and parameters in the the song.
----
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
 ---Renoise in general...
 ---
 
@@ -21,12 +18,12 @@ renoise.AudioDevice = {}
 ---@class renoise.AudioDevice
 ---
 ---Fixed name of the device.
----@field name string **READ-ONLY** 
----@field short_name string **READ-ONLY** 
+---@field name string **READ-ONLY**
+---@field short_name string **READ-ONLY**
 ---
 ---Configurable device display name. When empty `name` is displayed.
 ---@field display_name string
----@field display_name_observable renoise.Document.Observable 
+---@field display_name_observable renoise.Document.Observable
 ---
 ---Enable/bypass the device.
 ---@field is_active boolean !active = bypassed
@@ -43,10 +40,10 @@ renoise.AudioDevice = {}
 ---@field presets string[] **READ-ONLY** preset names
 ---
 ---Parameters.
----@field is_active_parameter renoise.DeviceParameter **READ-ONLY** 
+---@field is_active_parameter renoise.DeviceParameter **READ-ONLY**
 ---@field parameters renoise.DeviceParameter[] **READ-ONLY**
 ---
----**READ-ONLY** Returns whether or not the device provides its own custom GUI 
+---**READ-ONLY** Returns whether or not the device provides its own custom GUI
 ---(only available for some plugin devices)
 ---@field external_editor_available boolean
 ---
@@ -54,33 +51,32 @@ renoise.AudioDevice = {}
 ---external_editor_available), otherwise the external editor is opened/closed.
 ---@field external_editor_visible boolean true to show the editor, false to close it
 ---
----**READ-ONLY** Returns a string that uniquely identifies the device, from 
----`available_devices`. The string can be passed into: 
+---**READ-ONLY** Returns a string that uniquely identifies the device, from
+---`available_devices`. The string can be passed into:
 ---`renoise.song().tracks[]:insert_device_at()`
 ---@field device_path string
 
 ---### functions
 
----Access to a single preset name by index. Use properties 'presets' to iterate 
+---Access to a single preset name by index. Use properties 'presets' to iterate
 ---over all presets and to query the presets count.
 ---comment
 ---@param index integer
 ---@return string preset_name
 function renoise.AudioDevice:preset(index) end
 
----Access to a single parameter by index. Use properties 'parameters' to iterate 
+---Access to a single parameter by index. Use properties 'parameters' to iterate
 ---over all parameters and to query the parameter count.
 ---@param index integer
 ---@return renoise.DeviceParameter
 function renoise.AudioDevice:parameter(index) end
-
 
 --------------------------------------------------------------------------------
 ---## renoise.DeviceParameter
 
 ---A single parameter within an audio DSP effect (renoise.AudioDevice)
 ---@class renoise.DeviceParameter
-renoise.DeviceParameter = { }
+renoise.DeviceParameter = {}
 
 ---### constants
 

--- a/library/renoise/song/device.lua
+++ b/library/renoise/song/device.lua
@@ -122,7 +122,7 @@ renoise.DeviceParameter = {
 ---@field show_in_mixer_observable renoise.Document.Observable
 ---
 ---Values.
----@field value number value in [value_min - value_max]
+---@field value number value in Range: (value_min - value_max)
 ---@field value_observable renoise.Document.Observable
 ---
 ---@field value_string string

--- a/library/renoise/song/instrument.lua
+++ b/library/renoise/song/instrument.lua
@@ -1,124 +1,21 @@
---------------------------------------------------------------------------------
----@class renoise.Instrument
+---@meta
+---Do not try to execute this file. It's just a type definition file.
 ---
----### properties
+---Please read the `Introduction.md` in the Renoise scripting Documentation
+---folder first to get an overview about the complete API, and scripting for
+---Renoise in general...
 ---
----Currently active tab in the instrument GUI (samples, plugin or MIDI).
----@see renoise.
----@field active_tab renoise.Instrument.Tab
----@field active_tab_observable renoise.Document.Observable
---
----Instrument's name.
----@field name string
----@field name_observable renoise.Document.Observable
---
----Instrument's comment list. See renoise.song().comments for more info on
----how to get notified on changes and how to change it.
----@field comments string[]
----@field comments_observable renoise.Document.Observable
---
----Notifier which is called as soon as any paragraph in the comments change.
----@field comments_assignment_observable renoise.Document.Observable
---
----Set this to true to show the comments dialog after loading a song
----@field show_comments_after_loading  boolean
----@field show_comments_after_loading_observable renoise.Document.Observable
----
----Macro parameter pane visibility in the GUI.
----@field macros_visible boolean
----@field macros_visible_observable renoise.Document.Observable
----
----**READ-ONLY**
----Macro parameters.
----array with size Instrument.NUMBER_OF_MACROS
----@field macros renoise.InstrumentMacro[]
----
----Access the MIDI pitch-bend macro
----@field pitchbend_macro renoise.InstrumentMacro
----
----Access the MIDI modulation-wheel macro
----@field modulation_wheel_macro renoise.InstrumentMacro
----
----Access the MIDI channel pressure macro
----@field channel_pressure_macro renoise.InstrumentMacro
----
----Global linear volume of the instrument. Applied to all samples, MIDI and
----plugins in the instrument.
----@field volume number Range: (0-math.db2lin(6))
----@field volume_observable renoise.Document.Observable
----
----Global relative pitch in semi tones. Applied to all samples, MIDI and 
----plugins in the instrument.
----@field transpose number Range: (-120-120)
----@field transpose_observable renoise.Document.Observable
----
----Global trigger options (quantization and scaling options).
----@field trigger_options renoise.InstrumentTriggerOptions
----
----Sample mapping's overlap trigger mode.
----@field sample_mapping_overlap_mode renoise.Instrument.OverlapMode
----@field sample_mapping_overlap_mode_observable renoise.Document.Observable
----
----Phrase editor pane visibility in the GUI.
----@field phrase_editor_visible boolean
----@field phrase_editor_visible_observable renoise.Document.Observable
----
----Phrase playback.
----@field phrase_playback_mode renoise.Instrument.PhrasePlaybackMode
----@field phrase_playback_mode_observable renoise.Document.Observable
----
----Phrase playback program: 0 = Off, 1-126 = specific phrase, 127 = keymap.
----@field phrase_program number
----@field phrase_program_observablerenoise.Document.Observable
----
----**READ-ONLY**
----Phrases.
----@field phrases renoise.InstrumentPhrase[]
----@field phrases_observable renoise.Document.Observable
----
----**READ-ONLY**
----Phrase mappings.
----@field phrase_mappings renoise.InstrumentPhraseMapping[]
----@field phrase_mappings_observable renoise.Document.Observable
----
----**READ-ONLY**
----Samples slots.
----@field samples renoise.Sample[]
----@field samples_observable renoise.Document.Observable
----
----**READ-ONLY**
----Sample mappings (key/velocity to sample slot mappings).
----sample_mappings[LAYER_NOTE_ON/OFF][]. Sample mappings also can 
----be accessed via ---@field samples[].sample_mapping
----@field sample_mappings renoise.SampleMapping[]
----@field sample_mappings_observable renoise.Document.Observable
----
----**READ-ONLY**
----Sample modulation sets.
----@field sample_modulation_sets renoise.SampleModulationSet[]
----@field sample_modulation_sets_observable renoise.Document.Observable
----
----**READ-ONLY**
----Sample device chains.
----@field sample_device_chains renoise.SampleDeviceChain[]
----
----**READ-ONLY**
----MIDI input properties.
----@field midi_input_properties renoise.InstrumentMidiInputProperties
----
----**READ-ONLY**
----MIDI output properties.
----@field midi_output_properties renoise.InstrumentMidiOutputProperties
----
----**READ-ONLY**
----Plugin properties.
----@field plugin_properties renoise.InstrumentPluginProperties
 
+--------------------------------------------------------------------------------
+---## renoise.Instrument
 
 ---@class renoise.Instrument
 renoise.Instrument = {}
 
 ---### constants
+
+renoise.Instrument.NUMBER_OF_MACROS = 8
+renoise.Instrument.MAX_NUMBER_OF_PHRASES = 126
 
 ---@enum renoise.Instrument.Tab
 renoise.Instrument = {
@@ -148,9 +45,110 @@ renoise.Instrument = {
   OVERLAP_MODE_RANDOM = 2,
 }
 
-renoise.Instrument.NUMBER_OF_MACROS = 8
+---### properties
 
-renoise.Instrument.MAX_NUMBER_OF_PHRASES = 126
+---@class renoise.Instrument
+---
+---Currently active tab in the instrument GUI (samples, plugin or MIDI).
+---@see renoise.
+---@field active_tab renoise.Instrument.Tab
+---@field active_tab_observable renoise.Document.Observable
+--
+---Instrument's name.
+---@field name string
+---@field name_observable renoise.Document.Observable
+--
+---Instrument's comment list. See renoise.song().comments for more info on
+---how to get notified on changes and how to change it.
+---@field comments string[]
+---@field comments_observable renoise.Document.Observable
+--
+---Notifier which is called as soon as any paragraph in the comments change.
+---@field comments_assignment_observable renoise.Document.Observable
+--
+---Set this to true to show the comments dialog after loading a song
+---@field show_comments_after_loading  boolean
+---@field show_comments_after_loading_observable renoise.Document.Observable
+---
+---Macro parameter pane visibility in the GUI.
+---@field macros_visible boolean
+---@field macros_visible_observable renoise.Document.Observable
+---
+---**READ-ONLY** Macro parameters. Array with size Instrument.NUMBER_OF_MACROS.
+---@field macros renoise.InstrumentMacro[]
+---
+---Access the MIDI pitch-bend macro
+---@field pitchbend_macro renoise.InstrumentMacro
+---
+---Access the MIDI modulation-wheel macro
+---@field modulation_wheel_macro renoise.InstrumentMacro
+---
+---Access the MIDI channel pressure macro
+---@field channel_pressure_macro renoise.InstrumentMacro
+---
+---Global linear volume of the instrument. Applied to all samples, MIDI and
+---plugins in the instrument.
+---@field volume number Range: (0-math.db2lin(6))
+---@field volume_observable renoise.Document.Observable
+---
+---Range: (-120-120). Global relative pitch in semi tones.
+---Applied to all samples, MIDI and plugins in the instrument.
+---@field transpose number
+---@field transpose_observable renoise.Document.Observable
+---
+---Global trigger options (quantization and scaling options).
+---@field trigger_options renoise.InstrumentTriggerOptions
+---
+---Sample mapping's overlap trigger mode.
+---@field sample_mapping_overlap_mode renoise.Instrument.OverlapMode
+---@field sample_mapping_overlap_mode_observable renoise.Document.Observable
+---
+---Phrase editor pane visibility in the GUI.
+---@field phrase_editor_visible boolean
+---@field phrase_editor_visible_observable renoise.Document.Observable
+---
+---Phrase playback.
+---@field phrase_playback_mode renoise.Instrument.PhrasePlaybackMode
+---@field phrase_playback_mode_observable renoise.Document.Observable
+---
+---Phrase playback program: 0 = Off, 1-126 = specific phrase, 127 = keymap.
+---@field phrase_program number
+---@field phrase_program_observable renoise.Document.Observable
+---
+---**READ-ONLY** Phrases.
+---@field phrases renoise.InstrumentPhrase[]
+---@field phrases_observable renoise.Document.Observable
+---
+---**READ-ONLY** Phrase mappings.
+---@field phrase_mappings renoise.InstrumentPhraseMapping[]
+---@field phrase_mappings_observable renoise.Document.Observable
+---
+---**READ-ONLY** Samples slots.
+---@field samples renoise.Sample[]
+---@field samples_observable renoise.Document.Observable
+---
+---**READ-ONLY**
+---Sample mappings (key/velocity to sample slot mappings).
+---sample_mappings[LAYER_NOTE_ON/OFF][]. Sample mappings also can
+---be accessed via ---@field samples[].sample_mapping
+---@field sample_mappings renoise.SampleMapping[]
+---@field sample_mappings_observable renoise.Document.Observable
+---
+---**READ-ONLY** Sample modulation sets.
+---@field sample_modulation_sets renoise.SampleModulationSet[]
+---@field sample_modulation_sets_observable renoise.Document.Observable
+---
+---**READ-ONLY** Sample device chains.
+---@field sample_device_chains renoise.SampleDeviceChain[]
+---
+---**READ-ONLY** MIDI input properties.
+---@field midi_input_properties renoise.InstrumentMidiInputProperties
+---
+---**READ-ONLY** MIDI output properties.
+---@field midi_output_properties renoise.InstrumentMidiOutputProperties
+---
+---**READ-ONLY** Plugin properties.
+---@field plugin_properties renoise.InstrumentPluginProperties
 
 ---### functions
 
@@ -182,21 +180,21 @@ function renoise.Instrument:delete_phrase_at(index) end
 ---@return renoise.InstrumentPhrase
 function renoise.Instrument:phrase(index) end
 
----Returns true if a new phrase mapping can be inserted at the given 
----phrase mapping index (see See renoise.song().instruments[].phrase_mappings). 
+---Returns true if a new phrase mapping can be inserted at the given
+---phrase mapping index (see See renoise.song().instruments[].phrase_mappings).
 ---Passed phrase must exist and must not have a mapping yet.
 ---Phrase note mappings may not overlap and are sorted by note, so there
 ---can be max 119 phrases per instrument when each phrase is mapped to
----a single key only. To make up room for new phrases, access phrases by 
+---a single key only. To make up room for new phrases, access phrases by
 ---index, adjust their note_range, then call 'insert_phrase_mapping_at' again.
 ---@param index integer
 ---@return boolean
 function renoise.Instrument:can_insert_phrase_mapping_at(index) end
 
 ---Insert a new phrase mapping behind the given phrase mapping index.
----The new phrase mapping will by default use the entire free (note) range 
----between the previous and next phrase (if any). To adjust the note range 
----of the new phrase change its 'new_phrase_mapping.note_range' property. 
+---The new phrase mapping will by default use the entire free (note) range
+---between the previous and next phrase (if any). To adjust the note range
+---of the new phrase change its 'new_phrase_mapping.note_range' property.
 ---@param index integer
 ---@param phrase renoise.InstrumentPhrase
 ---@return renoise.InstrumentPhraseMapping new_mapping
@@ -213,8 +211,8 @@ function renoise.Instrument:delete_phrase_mapping_at(index) end
 function renoise.Instrument:phrase_mapping(index) end
 
 ---Insert a new empty sample. returns the new renoise.Sample object.
----Every newly inserted sample has a default mapping, which covers the 
----entire key and velocity range, or it gets added as drum kit mapping 
+---Every newly inserted sample has a default mapping, which covers the
+---entire key and velocity range, or it gets added as drum kit mapping
 ---when the instrument used a drum-kit mapping before the sample got added.
 ---@param index integer
 ---@return renoise.Sample new_sample
@@ -254,7 +252,7 @@ function renoise.Instrument:delete_sample_modulation_set_at(index) end
 ---Swap positions of two modulation sets.
 function renoise.Instrument:swap_sample_modulation_sets_at(index1, index2) end
 
----Access to a single sample modulation set by index. Use property 
+---Access to a single sample modulation set by index. Use property
 ---'sample_modulation_sets' to iterate over all sets and to query the set count.
 ---@param index integer
 ---@return renoise.SampleModulationSet
@@ -274,20 +272,33 @@ function renoise.Instrument:delete_sample_device_chain_at(index) end
 ---@param index2 integer
 function renoise.Instrument:swap_sample_device_chains_at(index1, index2) end
 
----Access to a single device chain by index. Use property 'sample_device_chains' 
+---Access to a single device chain by index. Use property 'sample_device_chains'
 ---to iterate over all chains and to query the chain count.
 ---@param index integer
 ---@return renoise.SampleDeviceChain
 function renoise.Instrument:sample_device_chain(index) end
 
 --------------------------------------------------------------------------------
+---## renoise.InstrumentTriggerOptions
+
 ---@class renoise.InstrumentTriggerOptions
---------------------------------------------------------------------------------
----
+renoise.InstrumentTriggerOptions = {}
+
+---### constants
+
+---@enum renoise.InstrumentTriggerOptions.QuantizeMode
+renoise.InstrumentTriggerOptions = {
+  QUANTIZE_NONE = 1,
+  QUANTIZE_LINE = 2,
+  QUANTIZE_BEAT = 3,
+  QUANTIZE_BAR = 4,
+}
+
 ---### properties
+
+---@class renoise.InstrumentTriggerOptions
 ---
----**READ-ONLY**
----List of all available scale modes.
+---**READ-ONLY** List of all available scale modes.
 ---@field available_scale_modes string[]
 ---
 ---Scale to use when transposing. One of 'available_scales'.
@@ -309,18 +320,3 @@ function renoise.Instrument:sample_device_chain(index) end
 ---Glide amount when monophonic. 0 == off, 255 = instant
 ---@field monophonic_glide number
 ---@field monophonic_glide_observable renoise.Document.Observable
-
-
----@class renoise.InstrumentTriggerOptions
-renoise.InstrumentTriggerOptions = {}
-
----### constants
-
----@enum renoise.InstrumentTriggerOptions.QuantizeMode
-
-renoise.InstrumentTriggerOptions = {
-  QUANTIZE_NONE = 1,
-  QUANTIZE_LINE = 2,
-  QUANTIZE_BEAT = 3,
-  QUANTIZE_BAR = 4,
-}

--- a/library/renoise/song/instrument.lua
+++ b/library/renoise/song/instrument.lua
@@ -1,8 +1,8 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
 ---Renoise in general...
 ---
 

--- a/library/renoise/song/instrument.lua
+++ b/library/renoise/song/instrument.lua
@@ -88,10 +88,10 @@ renoise.Instrument = {
 ---
 ---Global linear volume of the instrument. Applied to all samples, MIDI and
 ---plugins in the instrument.
----@field volume number Range: (0-math.db2lin(6))
+---@field volume number Range: (0 - math.db2lin(6))
 ---@field volume_observable renoise.Document.Observable
 ---
----Range: (-120-120). Global relative pitch in semi tones.
+---Range: (-120 - 120). Global relative pitch in semi tones.
 ---Applied to all samples, MIDI and plugins in the instrument.
 ---@field transpose number
 ---@field transpose_observable renoise.Document.Observable
@@ -159,9 +159,10 @@ function renoise.Instrument:clear() end
 ---@param instrument renoise.Instrument
 function renoise.Instrument:copy_from(instrument) end
 
----Access a single macro by index [1-NUMBER_OF_MACROS].
----See also property 'macros'.
----@param index integer Range: (1-renoise.Instrument.NUMBER_OF_MACROS)
+---Range: (1 - renoise.Instrument.NUMBER_OF_MACROS) 
+---Access a single macro by index.
+---See also property `macros`.
+---@param index integer 
 ---@return renoise.InstrumentMacro instrument_macro
 function renoise.Instrument:macro(index) end
 

--- a/library/renoise/song/instrument/macro.lua
+++ b/library/renoise/song/instrument/macro.lua
@@ -1,8 +1,8 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
 ---Renoise in general...
 ---
 

--- a/library/renoise/song/instrument/macro.lua
+++ b/library/renoise/song/instrument/macro.lua
@@ -1,8 +1,20 @@
---------------------------------------------------------------------------------
----@class renoise.InstrumentMacro
---------------------------------------------------------------------------------
+---@meta
+---Do not try to execute this file. It's just a type definition file.
 ---
+---Please read the `Introduction.md` in the Renoise scripting Documentation
+---folder first to get an overview about the complete API, and scripting for
+---Renoise in general...
+---
+
+--------------------------------------------------------------------------------
+---## renoise.InstrumentMacro
+
+---@class renoise.InstrumentMacro
+renoise.InstrumentMacro = {}
+
 ---### properties
+
+---@class renoise.InstrumentMacro
 ---
 ---Macro name as visible in the GUI when mappings are presents.
 ---@field name string
@@ -29,13 +41,29 @@
 function renoise.InstrumentMacro:mapping(index) end
 
 --------------------------------------------------------------------------------
+---## renoise.InstrumentMacroMapping
+
 ---@class renoise.InstrumentMacroMapping
---------------------------------------------------------------------------------
----
+renoise.InstrumentMacroMapping = {}
+
+---### constants
+
+---@enum renoise.InstrumentMacroMapping.Scaling
+renoise.InstrumentMacroMapping = {
+  SCALING_LOG_FAST = 1,
+  SCALING_LOG_SLOW = 2,
+  SCALING_LINEAR = 3,
+  SCALING_EXP_SLOW = 4,
+  SCALING_EXP_FAST = 5,
+}
+
 ---### properties
+
+---@class renoise.InstrumentMacroMapping
 ---
----**READ-ONLY**
----Linked parameter. Can be a sample FX- or modulation parameter. Never nil.
+---
+---**READ-ONLY** Linked parameter.
+---Can be a sample FX- or modulation parameter. Never nil.
 ---@field parameter renoise.DeviceParameter
 ---
 ---Min/max range in which the macro applies its value to the target parameter.
@@ -49,14 +77,3 @@ function renoise.InstrumentMacro:mapping(index) end
 ---Scaling which gets applied within the min/max range to set the dest value.
 ---@field parameter_scaling renoise.InstrumentMacroMapping.Scaling
 ---@field parameter_scaling_observable renoise.Document.Observable
-
----### constants
-
----@enum renoise.InstrumentMacroMapping.Scaling
-renoise.InstrumentMacroMapping = {
-  SCALING_LOG_FAST = 1,
-  SCALING_LOG_SLOW = 2,
-  SCALING_LINEAR = 3,
-  SCALING_EXP_SLOW = 4,
-  SCALING_EXP_FAST = 5,
-}

--- a/library/renoise/song/instrument/macro.lua
+++ b/library/renoise/song/instrument/macro.lua
@@ -21,11 +21,11 @@ renoise.InstrumentMacro = {}
 ---@field name_observable renoise.Document.Observable
 ---
 ---Macro value
----@field value number Range: (0-1)
+---@field value number Range: (0 - 1)
 ---@field value_observable renoise.Document.Observable
 ---
 ---Macro value string
----@field value_string string Range: (0-100)
+---@field value_string string Range: (0 - 100)
 ---@field value_string_observable renoise.Document.Observable
 ---
 ---**READ-ONLY** Macro mappings, target parameters
@@ -68,10 +68,10 @@ renoise.InstrumentMacroMapping = {
 ---
 ---Min/max range in which the macro applies its value to the target parameter.
 ---Max can be < than Min. Mapping is then flipped.
----@field parameter_min number Range: (0-1)
+---@field parameter_min number Range: (0 - 1)
 ---@field parameter_min_observable renoise.Document.Observable
 ---
----@field parameter_max number Range: (0-1)
+---@field parameter_max number Range: (0 - 1)
 ---@field parameter_max_observable renoise.Document.Observable
 ---
 ---Scaling which gets applied within the min/max range to set the dest value.

--- a/library/renoise/song/instrument/midi_input.lua
+++ b/library/renoise/song/instrument/midi_input.lua
@@ -1,12 +1,24 @@
---------------------------------------------------------------------------------
----@class renoise.InstrumentMidiInputProperties
---------------------------------------------------------------------------------
+---@meta
+---Do not try to execute this file. It's just a type definition file.
 ---
+---Please read the `Introduction.md` in the Renoise scripting Documentation
+---folder first to get an overview about the complete API, and scripting for
+---Renoise in general...
+---
+
+--------------------------------------------------------------------------------
+---## renoise.InstrumentMidiInputProperties
+
+---@class renoise.InstrumentMidiInputProperties
+renoise.InstrumentMidiInputProperties = {}
+
 ---### properties
+
+---@class renoise.InstrumentMidiInputProperties
 ---
 ---When setting new devices, device names must be one of
 ---renoise.Midi.available_input_devices.
----Devices are automatically opened when needed. To close a device, set its 
+---Devices are automatically opened when needed. To close a device, set its
 ---name to "", e.g. an empty string.
 ---@field device_name string
 ---@field device_name_observable renoise.Document.Observable

--- a/library/renoise/song/instrument/midi_input.lua
+++ b/library/renoise/song/instrument/midi_input.lua
@@ -1,8 +1,8 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
 ---Renoise in general...
 ---
 

--- a/library/renoise/song/instrument/midi_input.lua
+++ b/library/renoise/song/instrument/midi_input.lua
@@ -22,11 +22,11 @@ renoise.InstrumentMidiInputProperties = {}
 ---name to "", e.g. an empty string.
 ---@field device_name string
 ---@field device_name_observable renoise.Document.Observable
----@field channel integer Range: (1-16) 0 = Omni
+---@field channel integer Range: (1 - 16) 0 = Omni
 ---@field channel_observable renoise.Document.Observable
 ---Table of two numbers in range (0-119) where C-4 is 48
 ---@field note_range integer[]
 ---@field note_range_observable  renoise.Document.Observable
----Range: (1-song.sequencer_track_count) 0 = Current track
+---Range: (1 - song.sequencer_track_count) 0 = Current track
 ---@field assigned_track integer
 ---@field assigned_track_observable renoise.Document.Observable

--- a/library/renoise/song/instrument/midi_output.lua
+++ b/library/renoise/song/instrument/midi_output.lua
@@ -1,8 +1,8 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
 ---Renoise in general...
 ---
 

--- a/library/renoise/song/instrument/midi_output.lua
+++ b/library/renoise/song/instrument/midi_output.lua
@@ -1,8 +1,29 @@
---------------------------------------------------------------------------------
----@class renoise.InstrumentMidiOutputProperties
---------------------------------------------------------------------------------
+---@meta
+---Do not try to execute this file. It's just a type definition file.
 ---
+---Please read the `Introduction.md` in the Renoise scripting Documentation
+---folder first to get an overview about the complete API, and scripting for
+---Renoise in general...
+---
+
+--------------------------------------------------------------------------------
+---## renoise.InstrumentMidiOutputProperties
+
+---@class renoise.InstrumentMidiOutputProperties
+renoise.InstrumentMidiOutputProperties = {}
+
+---### constants
+
+---@enum renoise.InstrumentMidiOutputProperties.Type
+renoise.InstrumentMidiOutputProperties = {
+  TYPE_EXTERNAL = 1,
+  TYPE_LINE_IN_RET = 2,
+  TYPE_INTERNAL = 3, -- REWIRE
+}
+
 ---### properties
+
+---@class renoise.InstrumentMidiOutputProperties
 ---
 -- Note: ReWire device always start with "ReWire: " in the device_name and
 -- will always ignore the instrument_type and channel properties. MIDI
@@ -35,13 +56,3 @@
 ---
 ---@field duration number Range: (1-8000) 8000 = INF
 ---@field duration_observable renoise.Document.Observable
----
-
----### constants
-
----@enum renoise.InstrumentMidiOutputProperties.Type
-renoise.InstrumentMidiOutputProperties = {
-  TYPE_EXTERNAL = 1,
-  TYPE_LINE_IN_RET = 2,
-  TYPE_INTERNAL = 3, -- REWIRE
-}

--- a/library/renoise/song/instrument/midi_output.lua
+++ b/library/renoise/song/instrument/midi_output.lua
@@ -39,20 +39,20 @@ renoise.InstrumentMidiOutputProperties = {
 ---@field device_name string
 ---@field device_name_observable renoise.Document.Observable
 ---
----@field channel number Range: (1-16)
+---@field channel number Range: (1 - 16)
 ---@field channel_observable renoise.Document.Observable
 ---
----@field transpose number Range: (-120-120)
+---@field transpose number Range: (-120 - 120)
 ---@field transpose_observable renoise.Document.Observable
 ---
----@field program number Range: (1-128) 0 = OFF
+---@field program number Range: (1 - 128) 0 = OFF
 ---@field program_observable renoise.Document.Observable
 ---
----@field bank number Range: (1-65536) 0 = OFF
+---@field bank number Range: (1 - 65536) 0 = OFF
 ---@field bank_observable renoise.Document.Observable
 ---
----@field delay number Range: (0-100)
+---@field delay number Range: (0 - 100)
 ---@field delay_observable renoise.Document.Observable
 ---
----@field duration number Range: (1-8000) 8000 = INF
+---@field duration number Range: (1 - 8000) 8000 = INF
 ---@field duration_observable renoise.Document.Observable

--- a/library/renoise/song/instrument/phrase.lua
+++ b/library/renoise/song/instrument/phrase.lua
@@ -1,12 +1,46 @@
+---@meta
+---Do not try to execute this file. It's just a type definition file.
+---
+---Please read the `Introduction.md` in the Renoise scripting Documentation
+---folder first to get an overview about the complete API, and scripting for
+---Renoise in general...
+---
+
 --------------------------------------------------------------------------------
----General remarks: Phrases do use renoise.PatternLine objects just like the 
----pattern tracks do. When the instrument column is enabled and used, 
+---## renoise.InstrumentPhrase
+
+---@class renoise.InstrumentPhrase
+renoise.InstrumentPhrase = {}
+
+---### constants
+
+---Maximum number of lines that can be present in a phrase.
+renoise.InstrumentPhrase.MAX_NUMBER_OF_LINES = 512
+
+---Min/Maximum number of note columns that can be present in a phrase.
+renoise.InstrumentPhrase.MIN_NUMBER_OF_NOTE_COLUMNS = 1
+renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS = 12
+
+---Min/Maximum number of effect columns that can be present in a phrase.
+renoise.InstrumentPhrase.MIN_NUMBER_OF_EFFECT_COLUMNS = 0
+renoise.InstrumentPhrase.MAX_NUMBER_OF_EFFECT_COLUMNS = 8
+
+---@enum renoise.InstrumentPhrase.KeyTrackingMode
+renoise.InstrumentPhrase = {
+  ---Every note plays back the phrase unpitched from line 1.
+  KEY_TRACKING_NONE = 1,
+  ---Play the phrase transposed relative to the phrase's base_note.
+  KEY_TRACKING_TRANSPOSE = 2,
+  ---Trigger phrase from the beginning (note_range start) up to the end (note_range end).
+  KEY_TRACKING_OFFSET = 3,
+}
+
+---### properties
+
+---General remarks: Phrases do use renoise.PatternLine objects just like the
+---pattern tracks do. When the instrument column is enabled and used,
 ---not instruments, but samples are addressed/triggered in phrases.
 ---@class renoise.InstrumentPhrase
---------------------------------------------------------------------------------
----@class renoise.InstrumentPhrase
----
----### properties
 ---
 ---Name of the phrase as visible in the phrase editor and piano mappings.
 ---@field name string
@@ -15,26 +49,26 @@
 ---(Key)Mapping properties of the phrase or nil when no mapping is present.
 ---@field mapping renoise.InstrumentPhraseMapping?
 ---
----**READ-ONLY** 
+---**READ-ONLY**
 ---Quickly check if a phrase has some non empty pattern lines.
 ---@field is_empty boolean
 ---@field is_empty_observable renoise.Document.Observable
 ---
+---Default: 16, Range: (1-renoise.InstrumentPhrase.MAX_NUMBER_OF_LINES)
 ---Number of lines the phrase currently has.
----@field number_of_lines integer Default: 16 Range: (1-renoise.InstrumentPhrase.MAX_NUMBER_OF_LINES)
+---@field number_of_lines integer
 ---@field number_of_lines_observable renoise.Document.Observable
 ---
----**READ-ONLY** 
----Get all lines in a range [1, number_of_lines_in_pattern]
+---**READ-ONLY** Get all lines in a range [1, number_of_lines_in_pattern]
 ---@field lines renoise.PatternLine[]
 ---
----How many note columns are visible in the phrase.
 ---Range: (MIN_NUMBER_OF_NOTE_COLUMNS-MAX_NUMBER_OF_NOTE_COLUMNS)
----@field visible_note_columns integer 
+---How many note columns are visible in the phrase.
+---@field visible_note_columns integer
 ---@field visible_note_columns_observable  renoise.Document.Observable
 ---
----How many effect columns are visible in the phrase.
 ---Range: (MIN_NUMBER_OF_EFFECT_COLUMNS-MAX_NUMBER_OF_EFFECT_COLUMNS)
+---How many effect columns are visible in the phrase.
 ---@field visible_effect_columns integer
 ---@field visible_effect_columns_observable renoise.Document.Observable
 ---
@@ -42,34 +76,39 @@
 ---@field key_tracking renoise.InstrumentPhrase.KeyTrackingMode
 ---@field key_tracking_observable  renoise.Document.Observable
 ---
+---Range: (0-119) where C-4 is 48
 ---Phrase's base-note. Only relevant when key_tracking is set to transpose.
----@field base_note integer Range: (0-119) where C-4 is 48
+---@field base_note integer
 ---@field base_note_observable  renoise.Document.Observable
 ---
 ---Loop mode. The phrase plays as one-shot when disabled.
 ---@field looping boolean
 ---@field looping_observable  renoise.Document.Observable
 ---
+---Range: (1-number_of_lines)
 ---Loop start. Playback will start from the beginning before entering loop
----@field loop_start integer Range: (1-number_of_lines)
+---@field loop_start integer
 ---@field loop_start_observable  renoise.Document.Observable
 ---
+---Range: (loop_start-number_of_lines)
 ---Loop end. Needs to be > loop_start and <= number_of_lines
----@field loop_end integer Range: (loop_start-number_of_lines)
+---@field loop_end integer
 ---@field loop_end_observable  renoise.Document.Observable
 ---
 ---Phrase autoseek settings
 ---@field autoseek boolean
 ---@field autoseek_observable renoise.Document.Observable
 ---
----Phrase local lines per beat setting. New phrases get initialized with 
+---Range: (1-256)
+---Phrase local lines per beat setting. New phrases get initialized with
 ---the song's current LPB setting. TPL can not be configured in phrases.
----@field lpb integer Range: (1-256)
+---@field lpb integer
 ---@field lpb_observable renoise.Document.Observable
 ---
----Shuffle groove amount for a phrase. 
----0.0 = no shuffle (off), 1.0 = full shuffle 
----@field shuffle number Range: (0-1)
+---Range: (0-1)
+---Shuffle groove amount for a phrase.
+---0.0 = no shuffle (off), 1.0 = full shuffle
+---@field shuffle number
 ---@field shuffle_observable renoise.Document.Observable
 ---
 ---Column visibility.
@@ -88,31 +127,6 @@
 ---@field sample_effects_column_visible boolean
 ---@field sample_effects_column_visible_observable  renoise.Document.Observable
 
----### constants
-
-renoise.InstrumentPhrase = {}
-
----@enum renoise.InstrumentPhrase.KeyTrackingMode
-renoise.InstrumentPhrase = {
----Every note plays back the phrase unpitched from line 1.
-  KEY_TRACKING_NONE = 1,
----Play the phrase transposed relative to the phrase's base_note.
-  KEY_TRACKING_TRANSPOSE = 2,
----Trigger phrase from the beginning (note_range start) up to the end (note_range end).
-  KEY_TRACKING_OFFSET = 3,
-}
-
----Maximum number of lines that can be present in a phrase.
-renoise.InstrumentPhrase.MAX_NUMBER_OF_LINES = 512
-
----Min/Maximum number of note columns that can be present in a phrase.
-renoise.InstrumentPhrase.MIN_NUMBER_OF_NOTE_COLUMNS = 1
-renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS = 12
-
----Min/Maximum number of effect columns that can be present in a phrase.
-renoise.InstrumentPhrase.MIN_NUMBER_OF_EFFECT_COLUMNS = 0
-renoise.InstrumentPhrase.MAX_NUMBER_OF_EFFECT_COLUMNS = 8
-
 ---### functions
 
 ---Deletes all lines.
@@ -122,45 +136,66 @@ function renoise.InstrumentPhrase:clear() end
 ---@param phrase renoise.InstrumentPhrase
 function renoise.InstrumentPhrase:copy_from(phrase) end
 
----Access to a single line by index. Line must be [1-MAX_NUMBER_OF_LINES]). 
+---Range:(1-renoise.InstrumentPhrase.MAX_NUMBER_OF_LINES)
+---Access to a single line by index. Line must be [1-MAX_NUMBER_OF_LINES]).
 ---This is a !lot! more efficient than calling the property: lines[index] to
 ---randomly access lines.
----@param index integer Range:(1-renoise.InstrumentPhrase.MAX_NUMBER_OF_LINES)
+---@param index integer
 ---@return renoise.PatternLine
 function renoise.InstrumentPhrase:line(index) end
 
----Get a specific line range 
+---Get a specific line range
 ---@param index_from integer Range: (1-renoise.InstrumentPhrase.MAX_NUMBER_OF_LINES)
 ---@param index_to integer Range: (1-renoise.InstrumentPhrase.MAX_NUMBER_OF_LINES)
 ---@return renoise.PatternLine[]
 function renoise.InstrumentPhrase:lines_in_range(index_from, index_to) end
 
----Check/add/remove notifier functions or methods, which are called by 
+---Line iterator position.
+---@class PhraseLinePosition
+---@field line integer
+
+---@alias PhraseLineChangeCallback fun(pos: PhraseLinePosition)
+---@alias PhraseLineChangeCallbackWithContext fun(obj: table|userdata, pos: PhraseLinePosition)
+
+---Check/add/remove notifier functions or methods, which are called by
 ---Renoise as soon as any of the phrases's lines have changed.
 ---@see renoise.Pattern.has_line_notifier for more details.
----@param func PatternLineChangeCallback
+---@param func PhraseLineChangeCallbackWithContext
+---@param obj table|userdata
 ---@return boolean
-function renoise.InstrumentPhrase:has_line_notifier(func) end
+---@overload fun(self, func: PhraseLineChangeCallback): boolean
+function renoise.InstrumentPhrase:has_line_notifier(func, obj) end
 
----@param func PatternLineChangeCallback
-function renoise.InstrumentPhrase:add_line_notifier(func) end
+---@param func PhraseLineChangeCallbackWithContext
+---@param obj table|userdata
+---@overload fun(self, func: PhraseLineChangeCallback)
+function renoise.InstrumentPhrase:add_line_notifier(func, obj) end
 
----@param func PatternLineChangeCallback
-function renoise.InstrumentPhrase:remove_line_notifier(func) end
+---@param func PhraseLineChangeCallbackWithContext
+---@param obj table|userdata
+---@overload fun(self, func: PhraseLineChangeCallback)
+function renoise.InstrumentPhrase:remove_line_notifier(func, obj) end
 
 ---Same as line_notifier above, but the notifier only fires when the user
 ---added, changed or deleted a line with the computer keyboard.
----@param func PatternLineChangeCallback
+---@see renoise.Pattern.has_line_editoed_notifier for more details.
+---@param func PhraseLineChangeCallbackWithContext
+---@param obj table|userdata
 ---@return boolean
-function renoise.InstrumentPhrase:has_line_edited_notifier(func) end
+---@overload fun(self, func: PhraseLineChangeCallback): boolean
+function renoise.InstrumentPhrase:has_line_edited_notifier(func, obj) end
 
----@param func PatternLineChangeCallback
-function renoise.InstrumentPhrase:add_line_edited_notifier(func) end
+---@param func PhraseLineChangeCallbackWithContext
+---@param obj table|userdata
+---@overload fun(self, func: PhraseLineChangeCallback)
+function renoise.InstrumentPhrase:add_line_edited_notifier(func, obj) end
 
----@param func PatternLineChangeCallback
-function renoise.InstrumentPhrase:remove_line_edited_notifier(func) end
+---@param func PhraseLineChangeCallbackWithContext
+---@param obj table|userdata
+---@overload fun(self, func: PhraseLineChangeCallback)
+function renoise.InstrumentPhrase:remove_line_edited_notifier(func, obj) end
 
----Note column mute states. 
+---Note column mute states.
 ---@param column integer Range: (1-renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS)
 ---@return boolean
 function renoise.InstrumentPhrase:column_is_muted(column) end
@@ -173,7 +208,7 @@ function renoise.InstrumentPhrase:column_is_muted_observable(column) end
 ---@param muted boolean
 function renoise.InstrumentPhrase:set_column_is_muted(column, muted) end
 
----Note column names. 
+---Note column names.
 ---@param column integer Range: (1-renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS)
 ---@return string
 function renoise.InstrumentPhrase:column_name(column) end
@@ -196,21 +231,33 @@ function renoise.InstrumentPhrase:swap_note_columns_at(index1, index2) end
 ---@param index2 integer Range: (1-renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS)
 function renoise.InstrumentPhrase:swap_effect_columns_at(index1, index2) end
 
-
---TODO once comparison operators get implemented in lua-ls
 --### operators
---Compares line content. All other properties are ignored.
--- ==(InstrumentPhrase object, InstrumentPhrase object) 
--- -> [boolean]
--- ~=(InstrumentPhrase object, InstrumentPhrase object) 
--- -> [boolean]
 
+---Compares line content. All other properties are ignored.
+---operator==(phrase, phrase): boolean
+---operator~=(phrase, phrase): boolean
 
 --------------------------------------------------------------------------------
+---## renoise.InstrumentPhraseMapping
+
 ---@class renoise.InstrumentPhraseMapping
---------------------------------------------------------------------------------
----
+renoise.InstrumentPhraseMapping = {}
+
+---### constants
+
+---@enum renoise.InstrumentPhraseMapping.KeyTrackingMode
+renoise.InstrumentPhraseMapping = {
+  ---Every note plays back the phrase unpitched from line 1.
+  KEY_TRACKING_NONE = 1,
+  ---Play the phrase transposed relative to the phrase's base_note.
+  KEY_TRACKING_TRANSPOSE = 2,
+  ---Trigger phrase from the beginning (note_range start) up to the end (note_range end).
+  KEY_TRACKING_OFFSET = 3,
+}
+
 ---### properties
+
+---@class renoise.InstrumentPhraseMapping
 ---
 ---Linked phrase.
 ---@field phrase renoise.InstrumentPhrase
@@ -238,15 +285,3 @@ function renoise.InstrumentPhrase:swap_effect_columns_at(index1, index2) end
 ---
 ---@field loop_end integer
 ---@field loop_end_observable  renoise.Document.Observable
-
----### constants
-
----@enum renoise.InstrumentPhraseMapping.KeyTrackingMode
-renoise.InstrumentPhraseMapping = {
----Every note plays back the phrase unpitched from line 1.
-  KEY_TRACKING_NONE = 1,
----Play the phrase transposed relative to the phrase's base_note.
-  KEY_TRACKING_TRANSPOSE = 2,
----Trigger phrase from the beginning (note_range start) up to the end (note_range end).
-  KEY_TRACKING_OFFSET = 3,
-}

--- a/library/renoise/song/instrument/phrase.lua
+++ b/library/renoise/song/instrument/phrase.lua
@@ -1,8 +1,8 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
 ---Renoise in general...
 ---
 

--- a/library/renoise/song/instrument/phrase.lua
+++ b/library/renoise/song/instrument/phrase.lua
@@ -54,7 +54,7 @@ renoise.InstrumentPhrase = {
 ---@field is_empty boolean
 ---@field is_empty_observable renoise.Document.Observable
 ---
----Default: 16, Range: (1-renoise.InstrumentPhrase.MAX_NUMBER_OF_LINES)
+---Default: 16, Range: (1 - renoise.InstrumentPhrase.MAX_NUMBER_OF_LINES)
 ---Number of lines the phrase currently has.
 ---@field number_of_lines integer
 ---@field number_of_lines_observable renoise.Document.Observable
@@ -62,12 +62,12 @@ renoise.InstrumentPhrase = {
 ---**READ-ONLY** Get all lines in a range [1, number_of_lines_in_pattern]
 ---@field lines renoise.PatternLine[]
 ---
----Range: (MIN_NUMBER_OF_NOTE_COLUMNS-MAX_NUMBER_OF_NOTE_COLUMNS)
+---Range: (MIN_NUMBER_OF_NOTE_COLUMNS - MAX_NUMBER_OF_NOTE_COLUMNS)
 ---How many note columns are visible in the phrase.
 ---@field visible_note_columns integer
 ---@field visible_note_columns_observable  renoise.Document.Observable
 ---
----Range: (MIN_NUMBER_OF_EFFECT_COLUMNS-MAX_NUMBER_OF_EFFECT_COLUMNS)
+---Range: (MIN_NUMBER_OF_EFFECT_COLUMNS - MAX_NUMBER_OF_EFFECT_COLUMNS)
 ---How many effect columns are visible in the phrase.
 ---@field visible_effect_columns integer
 ---@field visible_effect_columns_observable renoise.Document.Observable
@@ -76,7 +76,7 @@ renoise.InstrumentPhrase = {
 ---@field key_tracking renoise.InstrumentPhrase.KeyTrackingMode
 ---@field key_tracking_observable  renoise.Document.Observable
 ---
----Range: (0-119) where C-4 is 48
+---Range: (0 - 119) where C-4 is 48
 ---Phrase's base-note. Only relevant when key_tracking is set to transpose.
 ---@field base_note integer
 ---@field base_note_observable  renoise.Document.Observable
@@ -85,12 +85,12 @@ renoise.InstrumentPhrase = {
 ---@field looping boolean
 ---@field looping_observable  renoise.Document.Observable
 ---
----Range: (1-number_of_lines)
+---Range: (1 - number_of_lines)
 ---Loop start. Playback will start from the beginning before entering loop
 ---@field loop_start integer
 ---@field loop_start_observable  renoise.Document.Observable
 ---
----Range: (loop_start-number_of_lines)
+---Range: (loop_start - number_of_lines)
 ---Loop end. Needs to be > loop_start and <= number_of_lines
 ---@field loop_end integer
 ---@field loop_end_observable  renoise.Document.Observable
@@ -99,13 +99,13 @@ renoise.InstrumentPhrase = {
 ---@field autoseek boolean
 ---@field autoseek_observable renoise.Document.Observable
 ---
----Range: (1-256)
+---Range: (1 - 256)
 ---Phrase local lines per beat setting. New phrases get initialized with
 ---the song's current LPB setting. TPL can not be configured in phrases.
 ---@field lpb integer
 ---@field lpb_observable renoise.Document.Observable
 ---
----Range: (0-1)
+---Range: (0 - 1)
 ---Shuffle groove amount for a phrase.
 ---0.0 = no shuffle (off), 1.0 = full shuffle
 ---@field shuffle number
@@ -136,8 +136,8 @@ function renoise.InstrumentPhrase:clear() end
 ---@param phrase renoise.InstrumentPhrase
 function renoise.InstrumentPhrase:copy_from(phrase) end
 
----Range:(1-renoise.InstrumentPhrase.MAX_NUMBER_OF_LINES)
----Access to a single line by index. Line must be [1-MAX_NUMBER_OF_LINES]).
+---Range: (1 - renoise.InstrumentPhrase.MAX_NUMBER_OF_LINES)
+---Access to a single line by index. Line must be in Range: (1 - MAX_NUMBER_OF_LINES).
 ---This is a !lot! more efficient than calling the property: lines[index] to
 ---randomly access lines.
 ---@param index integer
@@ -145,8 +145,8 @@ function renoise.InstrumentPhrase:copy_from(phrase) end
 function renoise.InstrumentPhrase:line(index) end
 
 ---Get a specific line range
----@param index_from integer Range: (1-renoise.InstrumentPhrase.MAX_NUMBER_OF_LINES)
----@param index_to integer Range: (1-renoise.InstrumentPhrase.MAX_NUMBER_OF_LINES)
+---@param index_from integer Range: (1 - renoise.InstrumentPhrase.MAX_NUMBER_OF_LINES)
+---@param index_to integer Range: (1 - renoise.InstrumentPhrase.MAX_NUMBER_OF_LINES)
 ---@return renoise.PatternLine[]
 function renoise.InstrumentPhrase:lines_in_range(index_from, index_to) end
 
@@ -196,39 +196,39 @@ function renoise.InstrumentPhrase:add_line_edited_notifier(func, obj) end
 function renoise.InstrumentPhrase:remove_line_edited_notifier(func, obj) end
 
 ---Note column mute states.
----@param column integer Range: (1-renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS)
+---@param column integer Range: (1 - renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS)
 ---@return boolean
 function renoise.InstrumentPhrase:column_is_muted(column) end
 
----@param column integer Range: (1-renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS)
+---@param column integer Range: (1 - renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS)
 ---@return renoise.Document.Observable
 function renoise.InstrumentPhrase:column_is_muted_observable(column) end
 
----@param column integer Range: (1-renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS)
+---@param column integer Range: (1 - renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS)
 ---@param muted boolean
 function renoise.InstrumentPhrase:set_column_is_muted(column, muted) end
 
 ---Note column names.
----@param column integer Range: (1-renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS)
+---@param column integer Range: (1 - renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS)
 ---@return string
 function renoise.InstrumentPhrase:column_name(column) end
 
----@param column integer Range: (1-renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS)
+---@param column integer Range: (1 - renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS)
 ---@return renoise.Document.Observable
 function renoise.InstrumentPhrase:column_name_observable(column) end
 
----@param column integer Range: (1-renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS)
+---@param column integer Range: (1 - renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS)
 ---@param name string
 function renoise.InstrumentPhrase:set_column_name(column, name) end
 
 ---Swap the positions of two note columns within a phrase.
----@param index1 integer Range: (1-renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS)
----@param index2 integer Range: (1-renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS)
+---@param index1 integer Range: (1 - renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS)
+---@param index2 integer Range: (1 - renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS)
 function renoise.InstrumentPhrase:swap_note_columns_at(index1, index2) end
 
 ---Swap the positions of two effect columns within a phrase.
----@param index1 integer Range: (1-renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS)
----@param index2 integer Range: (1-renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS)
+---@param index1 integer Range: (1 - renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS)
+---@param index2 integer Range: (1 - renoise.InstrumentPhrase.MAX_NUMBER_OF_NOTE_COLUMNS)
 function renoise.InstrumentPhrase:swap_effect_columns_at(index1, index2) end
 
 --### operators
@@ -267,13 +267,13 @@ renoise.InstrumentPhraseMapping = {
 ---@field key_tracking_observable  renoise.Document.Observable
 ---
 ---Phrase's base-note. Only relevant when key_tracking is set to transpose.
----@field base_note integer Range:(0-119) where C-4 is 48
+---@field base_note integer Range: (0 - 119) where C-4 is 48
 ---@field base_note_observable  renoise.Document.Observable
 ---
 ---Note range the mapping is triggered at. Phrases may not overlap, so
 ---note_range start can only be set behind previous's (if any) end and
 ---note_range end can only be set before next mapping's (if any) start.
----@field note_range integer[] Range: (0-119) where C-4 is 48
+---@field note_range integer[] Range: (0 - 119) where C-4 is 48
 ---@field note_range_observable  renoise.Document.Observable
 ---
 ---Loop mode. The phrase plays as one-shot when disabled.

--- a/library/renoise/song/instrument/plugin.lua
+++ b/library/renoise/song/instrument/plugin.lua
@@ -1,8 +1,8 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
 ---Renoise in general...
 ---
 

--- a/library/renoise/song/instrument/plugin.lua
+++ b/library/renoise/song/instrument/plugin.lua
@@ -1,5 +1,15 @@
+---@meta
+---Do not try to execute this file. It's just a type definition file.
+---
+---Please read the `Introduction.md` in the Renoise scripting Documentation
+---folder first to get an overview about the complete API, and scripting for
+---Renoise in general...
+---
+
+--------------------------------------------------------------------------------
+---## PluginInfo
+
 ---@class PluginInfo
----Each table has the following fields:
 ---@field path string The plugin's path used by load_plugin()
 ---@field name string The plugin's name
 ---@field short_name string The plugin's name as displayed in shortened lists
@@ -8,26 +18,27 @@
 ---@field is_bridged string true if the plugin is a bridged plugin
 
 --------------------------------------------------------------------------------
+---## renoise.InstrumentPluginProperties
+
 ---@class renoise.InstrumentPluginProperties
---------------------------------------------------------------------------------
----
+renoise.InstrumentPluginProperties = {}
+
 ---### properties
+
+---@class renoise.InstrumentPluginProperties
 ---
----List of all currently available plugins. This is a list of unique plugin
----names which also contains the plugin's type (VST/AU/DSSI/...), not including
----the vendor names as visible in Renoise's GUI. Aka, its an identifier, and not
----the name as visible in the GUI. When no plugin is loaded, the identifier is
----an empty string.
----**READ-ONLY**
+---**READ-ONLY** List of all currently available plugins. This is a list of
+---unique plugin names which also contains the plugin's type (VST/AU/DSSI/...),
+---not including the vendor names as visible in Renoise's GUI. So its an
+---identifier, and not the name as visible in the GUI. When no plugin is loaded,
+---the identifier is an empty string.
 ---@field available_plugins string[]
 ---
----**READ-ONLY**
----Returns a list of tables containing more information about the plugins.
+---**READ-ONLY** Returns a list of tables containing more information about the plugins.
 ---@field available_plugin_infos PluginInfo[]
 ---
----Returns true when a plugin is present; loaded successfully.
+---**READ-ONLY** Returns true when a plugin is present; loaded successfully.
 ---@see renoise.PluginProperties.plugin_device_observable for related notifications.
----**READ-ONLY**
 ---@field plugin_loaded boolean
 ---
 ---Valid object for successfully loaded plugins, otherwise nil. Alias plugin
@@ -38,20 +49,18 @@
 ---@field plugin_device renoise.InstrumentPluginDevice|renoise.AudioDevice|nil
 ---@field plugin_device_observable renoise.Document.Observable
 ---
----Valid for loaded and unloaded plugins.
----**READ-ONLY**
+---**READ-ONLY** Valid for loaded and unloaded plugins.
 ---@field alias_instrument_index integer 0 when no alias instrument is set
 ---@field alias_instrument_index_observable renoise.Document.Observable
----**READ-ONLY**
----@field alias_fx_track_index integer 0 when no alias FX is set
+---**READ-ONLY** 0 when no alias FX is set
+---@field alias_fx_track_index integer
 ---@field alias_fx_track_index_observable renoise.Document.Observable
----**READ-ONLY**
----@field alias_fx_device_index integer 0 when no alias FX is set
+---**READ-ONLY** 0 when no alias FX is set
+---@field alias_fx_device_index integer
 ---@field alias_fx_device_index_observable renoise.Document.Observable
 ---
----Valid for loaded and unloaded plugins. 
+---**READ-ONLY** Valid for loaded and unloaded plugins.
 ---target instrument index of the plugin's MIDI output (when present)
----**READ-ONLY**
 ---@field midi_output_routing_index integer 0 when no routing is set
 ---@field midi_output_routing_index_observable renoise.Document.Observable
 ---
@@ -68,7 +77,6 @@
 ---Valid for loaded and unloaded plugins.
 ---@field auto_suspend boolean
 ---@field auto_suspend_observable renoise.Document.Observable
----
 
 ---### functions
 
@@ -80,59 +88,63 @@
 function renoise.IntrumentPluginProperties:load_plugin(plugin_path) end
 
 --------------------------------------------------------------------------------
+---## renoise.InstrumentDevice
+
 ---@deprecated - alias for InstrumentPluginDevice
 ---@see renoise.InstrumentPluginDevice
+---
 ---@class renoise.InstrumentDevice
---------------------------------------------------------------------------------
 
 --------------------------------------------------------------------------------
+---## renoise.InstrumentPluginDevice
+
 ---@class renoise.InstrumentPluginDevice
---------------------------------------------------------------------------------
----
+renoise.InstrumentPluginDevice = {}
+
 ---### properties
+
+---@class renoise.InstrumentPluginDevice
 ---
----Device name.
----**READ-ONLY**
+---**READ-ONLY** Device name.
 ---@field name string
 ---**READ-ONLY**
 ---@field short_name string
 ---
 ---**READ-ONLY**
 ---@field presets string[]
----Preset handling.
----@field active_preset integer 0 when when none is active (or available)
+---Preset handling. 0 when when none is active (or available)
+---@field active_preset integer
 ---@field active_preset_observable renoise.Document.Observable
----@field active_preset_data string raw XML data of the active preset
+---raw XML data of the active preset
+---@field active_preset_data string
 ---
 ---**READ-ONLY**
 ---@field parameters renoise.DeviceParameter[]
 ---
----**READ-ONLY**
----Returns whether or not the plugin provides its own custom GUI.
+---**READ-ONLY** Returns whether or not the plugin provides its own custom GUI.
+---
 ---@field external_editor_available boolean
 ---
 ---When the plugin has no custom GUI, Renoise will create a dummy editor for it which
 ---lists the plugin parameters.
 ---set to true to show the editor, false to close it
----@field external_editor_visible boolean 
+---@field external_editor_visible boolean
 ---
----Returns a string that uniquely identifies the plugin
+---**READ-ONLY** Returns a string that uniquely identifies the plugin
 ---@see renoise.InstrumentPluginProperties.available_plugins for the list of valid paths
 ---The string can be passed into: renoise.InstrumentPluginProperties:load_plugin()
----**READ-ONLY**
 ---@field device_path string
 
 ---### functions
 
----Access to a single preset name by index. Use properties 'presets' to iterate 
+---Access to a single preset name by index. Use properties 'presets' to iterate
 ---over all presets and to query the presets count.
 ---@param index integer
 ---@return string
 function renoise.InstrumentPluginDevice:preset(index) end
 
----Access to a single parameter by index. Use properties 'parameters' to iterate 
+---Access to a single parameter by index. Use properties 'parameters' to iterate
 ---over all parameters and to query the parameter count.
 ---@param index integer
 ---@return renoise.DeviceParameter
 function renoise.InstrumentPluginDevice:parameter(index) end
-

--- a/library/renoise/song/instrument/plugin.lua
+++ b/library/renoise/song/instrument/plugin.lua
@@ -65,13 +65,13 @@ renoise.InstrumentPluginProperties = {}
 ---@field midi_output_routing_index_observable renoise.Document.Observable
 ---
 ---Valid for loaded and unloaded plugins.
----@field channel integer Range: (1-16)
+---@field channel integer Range: (1 - 16)
 ---@field channel_observable renoise.Document.Observable
----@field transpose integer Range: (-120-120)
+---@field transpose integer Range: (-120 - 120)
 ---@field transpose_observable renoise.Document.Observable
 ---
 ---Valid for loaded and unloaded plugins.
----@field volume number Range: (0.0-4.0) linear gain
+---@field volume number Range: (0.0 - 4.0) linear gain
 ---@field volume_observable renoise.Document.Observable
 ---
 ---Valid for loaded and unloaded plugins.

--- a/library/renoise/song/instrument/sample.lua
+++ b/library/renoise/song/instrument/sample.lua
@@ -1,92 +1,19 @@
---------------------------------------------------------------------------------
----@class renoise.Sample
---------------------------------------------------------------------------------
---- 
----### properties
+---@meta
+---Do not try to execute this file. It's just a type definition file.
 ---
----True, when the sample slot is an alias to a sliced master sample. Such sample 
----slots are read-only and automatically managed with the master samples slice 
----list.
----**READ-ONLY**
----@field is_slice_alias boolean
----Read/write access to the slice marker list of a sample. When new markers are 
----set or existing ones unset, existing 0S effects or notes to existing slices 
----will NOT be remapped (unlike its done with the insert/remove/move_slice_marker
----functions). See function insert_slice_marker for info about marker limitations 
----and preconditions.
----@field slice_markers integer[]
----@field slice_markers_observable renoise.Document.Observable 
----Name.
----@field name string
----@field name_observable renoise.Document.Observable
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
+---Renoise in general...
 ---
----Panning, volume.
----@field panning number Range: (0.0-1.0)
----@field panning_observable renoise.Document.Observable
----@field volume number Range: (0.0-4.0)
----@field volume_observable renoise.Document.Observable
----
----Tuning.
----@field transpose integer Range: (-120-120)
----@field transpose_observable renoise.Document.Observable
----@field fine_tune integer Range: (-127-127)
----@field fine_tune_observable renoise.Document.Observable
----
----Beat sync.
----@field beat_sync_enabled boolean
----@field beat_sync_enabled_observable renoise.Document.Observable
----@field beat_sync_lines integer Range: (1-512)
----@field beat_sync_lines_observable renoise.Document.Observable
----@field beat_sync_mode renoise.Sample.BeatSyncMode
----@field beat_sync_mode_observable renoise.Document.Observable
----
----Interpolation, new note action, oneshot, mute_group, autoseek, autofade.
----@field interpolation_mode renoise.Sample.InterpolationMode
----@field interpolation_mode_observable renoise.Document.Observable
----@field oversample_enabled  boolean
----@field oversample_enabled_observable renoise.Document.Observable 
----
----@field new_note_action renoise.Sample.NewNoteActionMode
----@field new_note_action_observable renoise.Document.Observable
----@field oneshot  boolean
----@field oneshot_observable renoise.Document.Observable 
----@field mute_group  integer Range: (0-15) where 0 means no group
----@field mute_group_observable renoise.Document.Observable 
----@field autoseek boolean
----@field autoseek_observable renoise.Document.Observable
----@field autofade boolean
----@field autofade_observable renoise.Document.Observable
----
----Loops.
----@field loop_mode renoise.Sample.LoopMode
----@field loop_mode_observable renoise.Document.Observable
----@field loop_release boolean
----@field loop_release_observable renoise.Document.Observable
----@field loop_start integer Range: (1-num_sample_frames)
----@field loop_start_observable renoise.Document.Observable
----@field loop_end integer Range: (1-num_sample_frames)
----@field loop_end_observable renoise.Document.Observable
----
----The linked modulation set. 0 when disable, else a valid index for the
----renoise.Instrument.sample_modulation_sets table
----@field modulation_set_index integer
----@field modulation_set_index_observable renoise.Document.Observable 
----
----The linked instrument device chain. 0 when disable, else a valid index for the
----renoise.Instrument.sample_device_chain table
----@field device_chain_index integer
----@field device_chain_index_observable renoise.Document.Observable 
----
----**READ-ONLY**
----@field sample_buffer renoise.SampleBuffer
----@field sample_buffer_observable renoise.Document.Observable
----
----Keyboard Note/velocity mapping
----**READ-ONLY**
----@field sample_mapping renoise.SampleMapping
 
+--------------------------------------------------------------------------------
+---## renoise.Sample
+
+---@class renoise.Sample
+renoise.Sample = {}
 
 ---### constants
+
 ---@enum renoise.Sample.InterpolationMode
 renoise.Sample = {
   INTERPOLATE_NONE = 1,
@@ -117,6 +44,89 @@ renoise.Sample = {
   NEW_NOTE_ACTION_SUSTAIN = 3,
 }
 
+---### properties
+
+---@class renoise.Sample
+---
+---**READ-ONLY** True, when the sample slot is an alias to a sliced master sample.
+---Such sample slots are read-only and automatically managed with the master samples
+---slice list.
+---@field is_slice_alias boolean
+---Read/write access to the slice marker list of a sample. When new markers are
+---set or existing ones unset, existing 0S effects or notes to existing slices
+---will NOT be remapped (unlike its done with the insert/remove/move_slice_marker
+---functions). See function insert_slice_marker for info about marker limitations
+---and preconditions.
+---@field slice_markers integer[]
+---@field slice_markers_observable renoise.Document.Observable
+---Name.
+---@field name string
+---@field name_observable renoise.Document.Observable
+---
+---Panning, volume.
+---@field panning number Range: (0.0-1.0)
+---@field panning_observable renoise.Document.Observable
+---@field volume number Range: (0.0-4.0)
+---@field volume_observable renoise.Document.Observable
+---
+---Tuning.
+---@field transpose integer Range: (-120-120)
+---@field transpose_observable renoise.Document.Observable
+---@field fine_tune integer Range: (-127-127)
+---@field fine_tune_observable renoise.Document.Observable
+---
+---Beat sync.
+---@field beat_sync_enabled boolean
+---@field beat_sync_enabled_observable renoise.Document.Observable
+---@field beat_sync_lines integer Range: (1-512)
+---@field beat_sync_lines_observable renoise.Document.Observable
+---@field beat_sync_mode renoise.Sample.BeatSyncMode
+---@field beat_sync_mode_observable renoise.Document.Observable
+---
+---Interpolation, new note action, oneshot, mute_group, autoseek, autofade.
+---@field interpolation_mode renoise.Sample.InterpolationMode
+---@field interpolation_mode_observable renoise.Document.Observable
+---@field oversample_enabled  boolean
+---@field oversample_enabled_observable renoise.Document.Observable
+---
+---@field new_note_action renoise.Sample.NewNoteActionMode
+---@field new_note_action_observable renoise.Document.Observable
+---@field oneshot  boolean
+---@field oneshot_observable renoise.Document.Observable
+---@field mute_group  integer Range: (0-15) where 0 means no group
+---@field mute_group_observable renoise.Document.Observable
+---@field autoseek boolean
+---@field autoseek_observable renoise.Document.Observable
+---@field autofade boolean
+---@field autofade_observable renoise.Document.Observable
+---
+---Loops.
+---@field loop_mode renoise.Sample.LoopMode
+---@field loop_mode_observable renoise.Document.Observable
+---@field loop_release boolean
+---@field loop_release_observable renoise.Document.Observable
+---@field loop_start integer Range: (1-num_sample_frames)
+---@field loop_start_observable renoise.Document.Observable
+---@field loop_end integer Range: (1-num_sample_frames)
+---@field loop_end_observable renoise.Document.Observable
+---
+---The linked modulation set. 0 when disable, else a valid index for the
+---renoise.Instrument.sample_modulation_sets table
+---@field modulation_set_index integer
+---@field modulation_set_index_observable renoise.Document.Observable
+---
+---The linked instrument device chain. 0 when disable, else a valid index for the
+---renoise.Instrument.sample_device_chain table
+---@field device_chain_index integer
+---@field device_chain_index_observable renoise.Document.Observable
+---
+---**READ-ONLY**
+---@field sample_buffer renoise.SampleBuffer
+---@field sample_buffer_observable renoise.Document.Observable
+---
+---**READ-ONLY** Keyboard Note/velocity mapping
+---@field sample_mapping renoise.SampleMapping
+
 ---### functions
 
 ---Reset, clear all sample settings and sample data.
@@ -128,21 +138,23 @@ function renoise.Sample:copy_from(sample) end
 
 ---Insert a new slice marker at the given sample position. Only samples in
 ---the first sample slot may use slices. Creating slices will automatically
----create sample aliases in the following slots: read-only sample slots that 
----play the sample slice and are mapped to notes. Sliced sample lists can not 
----be modified manually then. To update such aliases, modify the slice marker 
----list instead. 
+---create sample aliases in the following slots: read-only sample slots that
+---play the sample slice and are mapped to notes. Sliced sample lists can not
+---be modified manually then. To update such aliases, modify the slice marker
+---list instead.
 ---Existing 0S effects or notes will be updated to ensure that the old slices
 ---are played back just as before.
 ---@param marker_sample_pos integer
 function renoise.Sample:insert_slice_marker(marker_sample_pos) end
+
 ---Delete an existing slice marker. marker_sample_pos must point to an existing
----marker. See also property 'samples[].slice_markers'. Existing 0S effects or 
----notes will be updated to ensure that the old slices are played back just as 
+---marker. See also property 'samples[].slice_markers'. Existing 0S effects or
+---notes will be updated to ensure that the old slices are played back just as
 ---before.
 ---@param marker_sample_pos integer
 function renoise.Sample:delete_slice_marker(marker_sample_pos) end
----Change the sample position of an existing slice marker. see also property 
+
+---Change the sample position of an existing slice marker. see also property
 ---'samples[].slice_markers'.
 ---When moving a marker behind or before an existing other marker, existing 0S
 ---effects or notes will automatically be updated to ensure that the old slices
@@ -151,20 +163,22 @@ function renoise.Sample:delete_slice_marker(marker_sample_pos) end
 ---@param new_marker_pos integer
 function renoise.Sample:move_slice_marker(old_marker_pos, new_marker_pos) end
 
-
 --------------------------------------------------------------------------------
+---## renoise.SampleMapping
+
+---@class renoise.SampleMapping
+renoise.SampleMapping = {}
+
+---### properties
+
 ---General remarks: Sample mappings of sliced samples are read-only: can not be
 ---modified. See `sample_mappings[].read_only`
 ---@class renoise.SampleMapping
---------------------------------------------------------------------------------
 ---
----### properties
+---**READ-ONLY** True for sliced instruments. No sample mapping properties are
+---allowed to be modified, but can be read.
+---@field read_only boolean
 ---
----True for sliced instruments. No sample mapping properties are allowed to 
----be modified, but can be read.
----**READ-ONLY**
----@field read_only boolean 
----  
 ---Linked sample.
 ---@field sample renoise.Sample
 ---
@@ -174,57 +188,63 @@ function renoise.Sample:move_slice_marker(old_marker_pos, new_marker_pos) end
 ---
 ---Mappings velocity->volume and key->pitch options.
 ---@field map_velocity_to_volume boolean
----@field map_velocity_to_volume_observable renoise.Document.Observable 
+---@field map_velocity_to_volume_observable renoise.Document.Observable
 ---@field map_key_to_pitch boolean
----@field map_key_to_pitch_observable renoise.Document.Observable 
+---@field map_key_to_pitch_observable renoise.Document.Observable
 ---
 ---Mappings base-note. Final pitch of the played sample is:
 ---  played_note - mapping.base_note + sample.transpose + sample.finetune
 ---@field base_note integer  (0-119, c-4=48)]
----@field base_note_observable renoise.Document.Observable 
+---@field base_note_observable renoise.Document.Observable
 ---
 ---Note range the mapping is triggered for.
 ---table of two integers
 ---@field note_range integer[] Range: (0-119) where C-4 is 48
----@field note_range_observable renoise.Document.Observable 
+---@field note_range_observable renoise.Document.Observable
 ---
 ---Velocity range the mapping is triggered for.
 ---@field velocity_range integer[] Range: (0-127)
----@field velocity_range_observable renoise.Document.Observable 
+---@field velocity_range_observable renoise.Document.Observable
 
 --------------------------------------------------------------------------------
+---## renoise.SampleBuffer
+
+---@class renoise.SampleBuffer
+renoise.SampleBuffer = {}
+
+---### constants
+
+---@enum renoise.SampleBuffer.Channel
+renoise.SampleBuffer = {
+  CHANNEL_LEFT = 1,
+  CHANNEL_RIGHT = 2,
+  CHANNEL_LEFT_AND_RIGHT = 3,
+}
+
+---### properties
+
 ---NOTE: All properties are invalid when no sample data is present,
 ---'has_sample_data' returns false:
 ---@class renoise.SampleBuffer
---------------------------------------------------------------------------------
 ---
----### properties
----
----Check this before accessing properties
----**READ-ONLY**
+---**READ-ONLY** Check this before accessing properties
 ---@field has_sample_data boolean
 ---
+---**READ-ONLY** True, when the sample buffer can only be read, but not be
+---modified. true for sample aliases of sliced samples. To modify such sample
+---buffers, modify the sliced master sample buffer instead.
+---@field read_only boolean
+---**READ-ONLY** The current sample rate in Hz, like 44100.
+---@field sample_rate integer
 ---
----**READ-ONLY**
----True, when the sample buffer can only be read, but not be modified. true for
----sample aliases of sliced samples. To modify such sample buffers, modify the 
----sliced master sample buffer instead.
----@field read_only boolean 
----**READ-ONLY**
----The current sample rate in Hz, like 44100.
----@field sample_rate integer 
+---**READ-ONLY** The current bit depth, like 32, 16, 8.
+---@field bit_depth integer
 ---
----**READ-ONLY**
----The current bit depth, like 32, 16, 8.
----@field bit_depth integer 
+---**READ-ONLY** The integer of sample channels (1 or 2)
+---@field number_of_channels integer
 ---
----**READ-ONLY**
----The integer of sample channels (1 or 2)
----@field number_of_channels integer 
----
----**READ-ONLY**
----The sample frame count (integer of samples per channel)
----@field number_of_frames integer 
+---**READ-ONLY** The sample frame count (integer of samples per channel)
+---@field number_of_frames integer
 ---
 ---The first sample displayed in the sample editor view. Set together with
 ---DisplayLength to control zooming.
@@ -258,15 +278,6 @@ function renoise.Sample:move_slice_marker(old_marker_pos, new_marker_pos) end
 ---@field selected_channel renoise.SampleBuffer.Channel
 ---@field selected_channel_observable renoise.Document.Observable
 
----### constants
-
----@enum renoise.SampleBuffer.Channel
-renoise.SampleBuffer = {
-  CHANNEL_LEFT = 1,
-  CHANNEL_RIGHT = 2,
-  CHANNEL_LEFT_AND_RIGHT = 3,
-}
-
 ---### functions
 
 ---Create new sample data with the given rate, bit-depth, channel and frame
@@ -290,8 +301,8 @@ function renoise.SampleBuffer:delete_sample_data() end
 function renoise.SampleBuffer:sample_data(channel_index, frame_index) end
 
 ---Write access to samples in a sample data buffer. New samples values must be
----within [-1, 1] and will be clipped automatically. Sample buffers may be 
----read-only (see property 'read_only'). Attempts to write on such buffers 
+---within [-1, 1] and will be clipped automatically. Sample buffers may be
+---read-only (see property 'read_only'). Attempts to write on such buffers
 ---will result into errors.
 ---IMPORTANT: before modifying buffers, call 'prepare_sample_data_changes'.
 ---When you are done, call 'finalize_sample_data_changes' to generate undo/redo
@@ -321,10 +332,10 @@ function renoise.SampleBuffer:finalize_sample_data_changes() end
 function renoise.SampleBuffer:load_from(filename) end
 
 ---@alias SampleBuffer.ExportType
----| '"wav"'
----| '"flac"'
+---| "wav"
+---| "flac"
 ---Export sample data to a file. Possible errors are shown to the user,
----otherwise success is returned. 
+---otherwise success is returned.
 ---@param filename string
 ---@param format SampleBuffer.ExportType
 ---@return boolean success

--- a/library/renoise/song/instrument/sample.lua
+++ b/library/renoise/song/instrument/sample.lua
@@ -64,21 +64,21 @@ renoise.Sample = {
 ---@field name_observable renoise.Document.Observable
 ---
 ---Panning, volume.
----@field panning number Range: (0.0-1.0)
+---@field panning number Range: (0.0 - 1.0)
 ---@field panning_observable renoise.Document.Observable
----@field volume number Range: (0.0-4.0)
+---@field volume number Range: (0.0 - 4.0)
 ---@field volume_observable renoise.Document.Observable
 ---
 ---Tuning.
----@field transpose integer Range: (-120-120)
+---@field transpose integer Range: (-120 - 120)
 ---@field transpose_observable renoise.Document.Observable
----@field fine_tune integer Range: (-127-127)
+---@field fine_tune integer Range: (-127 - 127)
 ---@field fine_tune_observable renoise.Document.Observable
 ---
 ---Beat sync.
 ---@field beat_sync_enabled boolean
 ---@field beat_sync_enabled_observable renoise.Document.Observable
----@field beat_sync_lines integer Range: (1-512)
+---@field beat_sync_lines integer Range: (1 - 512)
 ---@field beat_sync_lines_observable renoise.Document.Observable
 ---@field beat_sync_mode renoise.Sample.BeatSyncMode
 ---@field beat_sync_mode_observable renoise.Document.Observable
@@ -93,7 +93,7 @@ renoise.Sample = {
 ---@field new_note_action_observable renoise.Document.Observable
 ---@field oneshot  boolean
 ---@field oneshot_observable renoise.Document.Observable
----@field mute_group  integer Range: (0-15) where 0 means no group
+---@field mute_group  integer Range: (0 - 15) where 0 means no group
 ---@field mute_group_observable renoise.Document.Observable
 ---@field autoseek boolean
 ---@field autoseek_observable renoise.Document.Observable
@@ -105,9 +105,9 @@ renoise.Sample = {
 ---@field loop_mode_observable renoise.Document.Observable
 ---@field loop_release boolean
 ---@field loop_release_observable renoise.Document.Observable
----@field loop_start integer Range: (1-num_sample_frames)
+---@field loop_start integer Range: (1 - num_sample_frames)
 ---@field loop_start_observable renoise.Document.Observable
----@field loop_end integer Range: (1-num_sample_frames)
+---@field loop_end integer Range: (1 - num_sample_frames)
 ---@field loop_end_observable renoise.Document.Observable
 ---
 ---The linked modulation set. 0 when disable, else a valid index for the
@@ -199,11 +199,11 @@ renoise.SampleMapping = {}
 ---
 ---Note range the mapping is triggered for.
 ---table of two integers
----@field note_range integer[] Range: (0-119) where C-4 is 48
+---@field note_range integer[] Range: (0 - 119) where C-4 is 48
 ---@field note_range_observable renoise.Document.Observable
 ---
 ---Velocity range the mapping is triggered for.
----@field velocity_range integer[] Range: (0-127)
+---@field velocity_range integer[] Range: (0 - 127)
 ---@field velocity_range_observable renoise.Document.Observable
 
 --------------------------------------------------------------------------------
@@ -248,16 +248,16 @@ renoise.SampleBuffer = {
 ---
 ---The first sample displayed in the sample editor view. Set together with
 ---DisplayLength to control zooming.
----@field display_start integer Range: (1-number_of_frames)
+---@field display_start integer Range: (1 - number_of_frames)
 ---@field display_start_observable renoise.Document.Observable
 ---
 ---The number of samples displayed in the sample editor view. Set together with
 ---DisplayStart to control zooming.
----@field display_length integer Range: (1-number_of_frames)
+---@field display_length integer Range: (1 - number_of_frames)
 ---@field display_length_observable renoise.Document.Observable
 ---
 ---Array of two integers, the start and end points of the sample editor display.
----@field display_range integer[] Range: (1-number_of_frames)
+---@field display_range integer[] Range: (1 - number_of_frames)
 ---@field display_range_observable renoise.Document.Observable
 ---
 ---The vertical zoom level where 1.0 is fully zoomed out.
@@ -266,12 +266,12 @@ renoise.SampleBuffer = {
 ---
 ---Selection range as visible in the sample editor. always valid. returns the entire
 ---buffer when no selection is present in the UI.
----@field selection_start integer Range: (1-number_of_frames)
+---@field selection_start integer Range: (1 - number_of_frames)
 ---@field selection_start_observable renoise.Document.Observable
----@field selection_end integer Range: (1-number_of_frames)
+---@field selection_end integer Range: (1 - number_of_frames)
 ---@field selection_end_observable renoise.Document.Observable
 ---Array of two integers
----@field selection_range integer[] Range: (1-number_of_frames)
+---@field selection_range integer[] Range: (1 - number_of_frames)
 ---@field selection_range_observable renoise.Document.Observable
 ---
 ---The selected channel.
@@ -297,7 +297,7 @@ function renoise.SampleBuffer:delete_sample_data() end
 ---Read access to samples in a sample data buffer.
 ---@param channel_index integer
 ---@param frame_index integer
----@return number[] values Range: (-1-1)
+---@return number[] values Range: (-1 - 1)
 function renoise.SampleBuffer:sample_data(channel_index, frame_index) end
 
 ---Write access to samples in a sample data buffer. New samples values must be

--- a/library/renoise/song/instrument/sample.lua
+++ b/library/renoise/song/instrument/sample.lua
@@ -1,5 +1,5 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
 ---Please read the introduction at https://github.com/renoise/xrnx/
 ---to get an overview about the complete API, and scripting for

--- a/library/renoise/song/instrument/sample_device_chain.lua
+++ b/library/renoise/song/instrument/sample_device_chain.lua
@@ -1,29 +1,38 @@
---------------------------------------------------------------------------------
----@class renoise.SampleDeviceChain
---------------------------------------------------------------------------------
+---@meta
+---Do not try to execute this file. It's just a type definition file.
 ---
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
+---Renoise in general...
+---
+
+--------------------------------------------------------------------------------
+---## renoise.SampleDeviceChain
+
+---@class renoise.SampleDeviceChain
+renoise.SampleDeviceChain = {}
+
 ---### properties
+
+---@class renoise.SampleDeviceChain
 ---
 ---Name of the audio effect chain.
 ---@field name string
 ---@field name_observable renoise.Document.Observable
 ---
----**READ-ONLY**
----Allowed, available devices for 'insert_device_at'.
+---**READ-ONLY** Allowed, available devices for 'insert_device_at'.
 ---@field available_devices string[]
 ---
----**READ-ONLY**
----Returns a list of tables containing more information about the devices. 
+---**READ-ONLY** Returns a list of tables containing more information about
+---the devices.
 ---@see renoise.Track.available_device_infos
 ---@field available_device_infos AudioDeviceInfo[]
 ---
----**READ-ONLY**
----Device access.
+---**READ-ONLY** Device access.
 ---@field devices renoise.AudioDevice[]
 ---@field devices_observable renoise.Document.Observable
 ---
----**READ-ONLY**
----Output routing.
+---**READ-ONLY** Output routing.
 ---@field available_output_routings string[]
 ---
 ---One of 'available_output_routings'
@@ -54,4 +63,4 @@ function renoise.SampleDeviceChain:swap_devices_at(index1, index2) end
 ---Access to a single device in the chain.
 ---@param index integer
 ---@return renoise.AudioDevice
-function renoise.SampleDeviceChain:device(index)  end
+function renoise.SampleDeviceChain:device(index) end

--- a/library/renoise/song/instrument/sample_device_chain.lua
+++ b/library/renoise/song/instrument/sample_device_chain.lua
@@ -1,5 +1,5 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
 ---Please read the introduction at https://github.com/renoise/xrnx/
 ---to get an overview about the complete API, and scripting for

--- a/library/renoise/song/instrument/sample_modulation.lua
+++ b/library/renoise/song/instrument/sample_modulation.lua
@@ -1,13 +1,25 @@
---------------------------------------------------------------------------------
----@class renoise.SampleModulationSet
---------------------------------------------------------------------------------
+---@meta
+---Do not try to execute this file. It's just a type definition file.
 ---
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
+---Renoise in general...
+---
+
+--------------------------------------------------------------------------------
+---## renoise.SampleModulationSet
+
+---@class renoise.SampleModulationSet
+renoise.SampleModulationSet = {}
+
 ---### properties
+
+---@class renoise.SampleModulationSet
 ---
 ---Name of the modulation set.
 ---@field name string
 ---@field name_observable renoise.Document.Observable
----  
+---
 ---Input value for the volume domain
 ---@field volume_input renoise.DeviceParameter
 ---
@@ -28,31 +40,26 @@
 ---
 ---Pitch range in semitones
 ---@field pitch_range  integer Range: (1 - 96)
----@field pitch_range_observable renoise.Document.Observable 
+---@field pitch_range_observable renoise.Document.Observable
 ---
----**READ-ONLY**
----All available devices, to be used in 'insert_device_at'.
+---**READ-ONLY** All available devices, to be used in 'insert_device_at'.
 ---@field available_devices string[]
 ---
----**READ-ONLY**
----Device list access.
+---**READ-ONLY** Device list access.
 ---@field devices renoise.SampleModulationDevice[]
 ---@field devices_observable renoise.Document.Observable
 ---
----**READ-ONLY**
----Filter version. 
+---**READ-ONLY** Filter version.
 ---@see renoise.SampleModulationSet.upgrade_filter_version
 ---@field filter_version integer 1,2 or 3 which is the latest version
 ---@field filter_version_observable renoise.Document.Observable
 ---
----Filter type.
----**READ-ONLY**
+---**READ-ONLY** Filter type.
 ---@field available_filter_types string[]
 ---
 ---@see renoise.SampleModulationSet.available_filter_types
 ---@field filter_type string a valid filter type
 ---@field filter_type_observable renoise.Document.Observable
----
 
 ---### functions
 
@@ -68,81 +75,26 @@ function renoise.SampleModulationSet:copy_from(other_set) end
 ---@param device_path string
 ---@param index integer
 ---@return renoise.SampleModulationDevice new_sample_modulation_device
-function renoise.SampleModulationSet:insert_device_at(device_path, index)  end
+function renoise.SampleModulationSet:insert_device_at(device_path, index) end
 
 ---Delete a device at the given index.
 ---@param index integer
 function renoise.SampleModulationSet:delete_device_at(index) end
 
----Access a single device by index.  
+---Access a single device by index.
 ---@param index integer
 ---@return renoise.SampleModulationDevice
-function renoise.SampleModulationSet:device(index)  end
+function renoise.SampleModulationSet:device(index) end
 
- ---upgrade filter type to the latest version. Tries to find a somewhat matching
- ---filter in the new version, but things quite likely won't sound the same.
+---upgrade filter type to the latest version. Tries to find a somewhat matching
+---filter in the new version, but things quite likely won't sound the same.
 function renoise.SampleModulationSet:upgrade_filter_version() end
 
 --------------------------------------------------------------------------------
+---## renoise.SampleModulationDevice
+
 ---@class renoise.SampleModulationDevice
---------------------------------------------------------------------------------
----
----### properties
----
----Fixed name of the device.
----**READ-ONLY**
----@field name string
----
----**READ-ONLY**
----@field short_name string
----
----Configurable device display name.
----@field display_name  string
----@field display_name_observable renoise.Document.Observable 
----
----@deprecated use 'is_active' instead
----@see renoise.SampleModulationSet.is_active
----@field enabled boolean
----@field enabled_observable renoise.Document.Observable
----
----Enable/bypass the device.
----@field is_active boolean not active = bypassed
----@field is_active_observable renoise.Document.Observable
----
----Maximize state in modulation chain.
----@field is_maximized boolean
----@field is_maximized_observable renoise.Document.Observable
----
----Where the modulation gets applied (Volume, Pan, Pitch, Cutoff, Resonance).
----**READ-ONLY**
----@field target renoise.SampleModulationDevice.TargetType
----
----Modulation operator: how the device applies.
----@field operator renoise.SampleModulationDevice.OperatorType
----@field operator_observable renoise.Document.Observable
----
----Modulation polarity: 
----when bipolar, the device applies it's values in a -1 to 1 range,
----when unipolar in a 0 to 1 range.
----@field bipolar boolean
----@field bipolar_observable renoise.Document.Observable
----
----**READ-ONLY**
----When true, the device has one of more time parameters, which can be switched to operate
----in synced or unsynced mode (see tempo_synced)
----@field tempo_sync_switching_allowed boolean
----
----When true and the device supports sync switching (see 'tempo_sync_switching_allowed'),
----the device operates in wall-clock (ms) instead of beat times.
----@field tempo_synced boolean
----@field tempo_synced_observable renoise.Document.Observable
----  
----**READ-ONLY**
----Generic access to all parameters of this device.
----@field is_active_parameter renoise.DeviceParameter
----
----**READ-ONLY**
----@field parameters renoise.DeviceParameter[]
+renoise.SampleModulationDevice = {}
 
 ---### constants
 
@@ -164,6 +116,64 @@ renoise.SampleModulationDevice = {
   OPERATOR_DIV = 4,
 }
 
+---### properties
+
+---@class renoise.SampleModulationDevice
+---
+---**READ-ONLY** Fixed name of the device.
+---@field name string
+---
+---**READ-ONLY**
+---@field short_name string
+---
+---Configurable device display name.
+---@field display_name  string
+---@field display_name_observable renoise.Document.Observable
+---
+---@deprecated use 'is_active' instead
+---@see renoise.SampleModulationSet.is_active
+---@field enabled boolean
+---@field enabled_observable renoise.Document.Observable
+---
+---Enable/bypass the device.
+---@field is_active boolean not active = bypassed
+---@field is_active_observable renoise.Document.Observable
+---
+---Maximize state in modulation chain.
+---@field is_maximized boolean
+---@field is_maximized_observable renoise.Document.Observable
+---
+---**READ-ONLY** Where the modulation gets applied (Volume,
+---Pan, Pitch, Cutoff, Resonance).
+---@field target renoise.SampleModulationDevice.TargetType
+---
+---Modulation operator: how the device applies.
+---@field operator renoise.SampleModulationDevice.OperatorType
+---@field operator_observable renoise.Document.Observable
+---
+---Modulation polarity:
+---when bipolar, the device applies it's values in a -1 to 1 range,
+---when unipolar in a 0 to 1 range.
+---@field bipolar boolean
+---@field bipolar_observable renoise.Document.Observable
+---
+---**READ-ONLY** When true, the device has one of more time parameters,
+---which can be switched to operate in synced or unsynced mode.
+--- see also field tempo_synced.
+---@field tempo_sync_switching_allowed boolean
+---
+---When true and the device supports sync switching the device operates
+---in wall-clock (ms) instead of beat times.
+---see also property 'tempo_sync_switching_allowed'
+---@field tempo_synced boolean
+---@field tempo_synced_observable renoise.Document.Observable
+---
+---**READ-ONLY** Generic access to all parameters of this device.
+---@field is_active_parameter renoise.DeviceParameter
+---
+---**READ-ONLY**
+---@field parameters renoise.DeviceParameter[]
+
 ---### functions
 
 ---Reset the device to its default state.
@@ -174,30 +184,49 @@ function renoise.SampleModulationDevice:init() end
 ---@param other_device renoise.SampleModulationDevice
 function renoise.SampleModulationDevice:copy_from(other_device) end
 
----Access to a single parameter by index. Use properties 'parameters' to iterate 
+---Access to a single parameter by index. Use properties 'parameters' to iterate
 ---over all parameters and to query the parameter count.
 ---@param index integer
 ---@return renoise.DeviceParameter
 function renoise.SampleModulationDevice:parameter(index) end
 
 --------------------------------------------------------------------------------
----@class renoise.SampleOperandModulationDevice : renoise.SampleModulationDevice
---------------------------------------------------------------------------------
----
+---## renoise.SampleOperandModulationDevice
+
+---@class renoise.SampleOperandModulationDevice
+renoise.SampleOperandModulationDevice = {}
+
 ---### properties
+
+---@class renoise.SampleOperandModulationDevice : renoise.SampleModulationDevice
 ---
 ---Operand value.
----@field value  renoise.DeviceParameter
+---@field value renoise.DeviceParameter
 
 --------------------------------------------------------------------------------
----@class renoise.SampleFaderModulationDevice : renoise.SampleModulationDevice
---------------------------------------------------------------------------------
----
+---## renoise.SampleFaderModulationDevice
+
+---@class renoise.SampleFaderModulationDevice
+renoise.SampleFaderModulationDevice = {}
+
+---### constants
+
+---@enum renoise.SampleFaderModulationDevice.ScalingType
+renoise.SampleFaderModulationDevice = {
+  SCALING_LOG_FAST = 1,
+  SCALING_LOG_SLOW = 2,
+  SCALING_LINEAR = 3,
+  SCALING_EXP_SLOW = 4,
+  SCALING_EXP_FAST = 5,
+}
+
 ---### properties
+
+---@class renoise.SampleFaderModulationDevice : renoise.SampleModulationDevice
 ---
 ---Scaling mode.
 ---@field scaling renoise.SampleFaderModulationDevice.ScalingType
----@field scaling_observable renoise.Document.Observable 
+---@field scaling_observable renoise.Document.Observable
 ---
 ---Start value.
 ---@field from renoise.DeviceParameter
@@ -208,22 +237,16 @@ function renoise.SampleModulationDevice:parameter(index) end
 ---Delay.
 ---@field delay renoise.DeviceParameter
 ---
----### constants
----
----@enum renoise.SampleFaderModulationDevice.ScalingType
-renoise.SampleFaderModulationDevice = {
-  SCALING_LOG_FAST = 1,
-  SCALING_LOG_SLOW = 2,
-  SCALING_LINEAR = 3,
-  SCALING_EXP_SLOW = 4,
-  SCALING_EXP_FAST = 5,
-}
 
 --------------------------------------------------------------------------------
----@class renoise.SampleAhdrsModulationDevice : renoise.SampleModulationDevice
---------------------------------------------------------------------------------
----
+---## renoise.SampleAhdrsModulationDevice
+
+---@class renoise.SampleAhdrsModulationDevice
+renoise.SampleAhdrsModulationDevice = {}
+
 ---### properties
+
+---@class renoise.SampleAhdrsModulationDevice : renoise.SampleModulationDevice
 ---
 ---Attack duration.
 ---@field attack renoise.DeviceParameter with range (0-1)
@@ -236,12 +259,15 @@ renoise.SampleFaderModulationDevice = {
 ---Release duration.
 ---@field release renoise.DeviceParameter with range (0-1)
 
+--------------------------------------------------------------------------------
+---### renoise.SampleKeyTrackingModulationDevice
 
---------------------------------------------------------------------------------
----@class renoise.SampleKeyTrackingModulationDevice : renoise.SampleModulationDevice
---------------------------------------------------------------------------------
----
+---@class renoise.SampleKeyTrackingModulationDevice
+renoise.SampleKeyTrackingModulationDevice = {}
+
 ---### properties
+
+---@class renoise.SampleKeyTrackingModulationDevice : renoise.SampleModulationDevice
 ---
 ---Min/Max key value.
 ---@field min renoise.DeviceParameter with range (0-119)
@@ -249,19 +275,10 @@ renoise.SampleFaderModulationDevice = {
 
 
 --------------------------------------------------------------------------------
----@class renoise.SampleVelocityTrackingModulationDevice : renoise.SampleModulationDevice
---------------------------------------------------------------------------------
----
----### properties
----
----Mode.
----@field mode renoise.SampleVelocityTrackingModulationDevice.Mode
----@field mode_observable renoise.Document.Observable 
----
----
----Min/Max velocity.
----@field min renoise.DeviceParameter with range (0-127)
----@field max renoise.DeviceParameter with range (0-127)
+---## renoise.SampleVelocityTrackingModulationDevice
+
+---@class renoise.SampleVelocityTrackingModulationDevice
+renoise.SampleVelocityTrackingModulationDevice = {}
 
 ---### constants
 
@@ -271,15 +288,52 @@ renoise.SampleVelocityTrackingModulationDevice = {
   MODE_SCALE = 2,
 }
 
---------------------------------------------------------------------------------
----@class renoise.SampleEnvelopeModulationDevice : renoise.SampleModulationDevice
---------------------------------------------------------------------------------
----
 ---### properties
+
+---@class renoise.SampleVelocityTrackingModulationDevice : renoise.SampleModulationDevice
+---
+---Mode.
+---@field mode renoise.SampleVelocityTrackingModulationDevice.Mode
+---@field mode_observable renoise.Document.Observable
+---
+---
+---Min/Max velocity.
+---@field min renoise.DeviceParameter with range (0-127)
+---@field max renoise.DeviceParameter with range (0-127)
+
+--------------------------------------------------------------------------------
+---## renoise.SampleEnvelopeModulationDevice
+
+---@class renoise.SampleEnvelopeModulationDevice
+renoise.SampleEnvelopeModulationDevice = {}
+
+---### constants
+
+renoise.SampleEnvelopeModulationDevice.MIN_NUMBER_OF_POINTS = 6
+renoise.SampleEnvelopeModulationDevice.MAX_NUMBER_OF_POINTS = 6144
+
+---@enum renoise.SampleEnvelopeModulationDevice.PlayMode
+renoise.SampleEnvelopeModulationDevice = {
+  PLAYMODE_POINTS = 1,
+  PLAYMODE_LINES = 2,
+  PLAYMODE_CURVES = 3,
+}
+
+---@enum renoise.SampleEnvelopeModulationDevice.LoopMode
+renoise.SampleEnvelopeModulationDevice = {
+  LOOP_MODE_OFF = 1,
+  LOOP_MODE_FORWARD = 2,
+  LOOP_MODE_REVERSE = 3,
+  LOOP_MODE_PING_PONG = 4,
+}
+
+---### properties
+
+---@class renoise.SampleEnvelopeModulationDevice : renoise.SampleModulationDevice
 ---
 ---External editor visibility.
 --- set to true to show the editor, false to close it
----@field external_editor_visible boolean 
+---@field external_editor_visible boolean
 ---
 ---Play mode (interpolation mode).
 ---@field play_mode renoise.SampleEnvelopeModulationDevice.PlayMode
@@ -326,28 +380,6 @@ renoise.SampleVelocityTrackingModulationDevice = {
 ---An envelope point's scaling (used in 'lines' playback mode only - 0.0 is linear).
 ---@field scaling number Range: (-1.0-1.0)
 
-
----### constants
-
----@enum renoise.SampleEnvelopeModulationDevice.PlayMode
-renoise.SampleEnvelopeModulationDevice = {
-  PLAYMODE_POINTS = 1,
-  PLAYMODE_LINES = 2,
-  PLAYMODE_CURVES = 3,
-}
-
----@enum renoise.SampleEnvelopeModulationDevice.LoopMode
-renoise.SampleEnvelopeModulationDevice = {
-  LOOP_MODE_OFF = 1,
-  LOOP_MODE_FORWARD = 2,
-  LOOP_MODE_REVERSE = 3,
-  LOOP_MODE_PING_PONG = 4,
-}
-
-renoise.SampleEnvelopeModulationDevice.MIN_NUMBER_OF_POINTS = 6
-renoise.SampleEnvelopeModulationDevice.MAX_NUMBER_OF_POINTS = 6144
-
-
 ---### functions
 
 ---Reset the envelope back to its default initial state.
@@ -377,23 +409,38 @@ function renoise.SampleEnvelopeModulationDevice:has_point_at(time) end
 ---@param time integer Range: (1-envelope.length)
 ---@param value number Range: (0.0-1.0)
 ---@param scaling number? Range: (-1.0-1.0)
----Add a new point value (or replace any existing value) at time. 
+---Add a new point value (or replace any existing value) at time.
 function renoise.SampleEnvelopeModulationDevice:add_point_at(time, value, scaling) end
 
 ---Removes a point at the given time. Point must exist.
 ---@param time integer
 function renoise.SampleEnvelopeModulationDevice:remove_point_at(time) end
 
+--------------------------------------------------------------------------------
+---## renoise.SampleStepperModulationDevice
 
---------------------------------------------------------------------------------
----@class renoise.SampleStepperModulationDevice :  renoise.SampleModulationDevice
---------------------------------------------------------------------------------
----
+---@class renoise.SampleStepperModulationDevice
+renoise.SampleStepperModulationDevice = {}
+
+---### constants
+
+renoise.SampleStepperModulationDevice.MIN_NUMBER_OF_POINTS = 1
+renoise.SampleStepperModulationDevice.MAX_NUMBER_OF_POINTS = 256
+
+---@enum renoise.SampleStepperModulationDevice.PlayMode
+renoise.SampleStepperModulationDevice = {
+  PLAYMODE_POINTS = 1,
+  PLAYMODE_LINES = 2,
+  PLAYMODE_CURVES = 3,
+}
+
 ---### properties
+
+---@class renoise.SampleStepperModulationDevice :  renoise.SampleModulationDevice
 ---
 ---External editor visibility.
 ---set to true to show he editor, false to close it
----@field external_editor_visible boolean 
+---@field external_editor_visible boolean
 ---
 ---Play mode (interpolation mode).
 ---@field play_mode renoise.SampleStepperModulationDevice.PlayMode
@@ -423,19 +470,6 @@ function renoise.SampleEnvelopeModulationDevice:remove_point_at(time) end
 ---An envelope point's scaling (used in 'lines' playback mode only - 0.0 is linear).
 ---@field scaling number Range: (-1.0-1.0)
 
-
----### constants
-
----@enum renoise.SampleStepperModulationDevice.PlayMode
-renoise.SampleStepperModulationDevice = {
-  PLAYMODE_POINTS = 1,
-  PLAYMODE_LINES = 2,
-  PLAYMODE_CURVES = 3,
-}
-
-renoise.SampleStepperModulationDevice.MIN_NUMBER_OF_POINTS = 1
-renoise.SampleStepperModulationDevice.MAX_NUMBER_OF_POINTS = 256
-
 ---### functions
 
 ---Reset the envelope back to its default initial state.
@@ -462,7 +496,7 @@ function renoise.SampleStepperModulationDevice:copy_points_from(other_device) en
 ---@return boolean
 function renoise.SampleStepperModulationDevice:has_point_at(time) end
 
----Add a new point value (or replace any existing value) at time. 
+---Add a new point value (or replace any existing value) at time.
 ---@param time integer
 ---@param value number
 ---@param scaling number?
@@ -472,13 +506,25 @@ function renoise.SampleStepperModulationDevice:add_point_at(time, value, scaling
 ---@param time integer
 function renoise.SampleStepperModulationDevice:remove_point_at(time) end
 
-
-
 --------------------------------------------------------------------------------
----@class renoise.SampleLfoModulationDevice : renoise.SampleModulationDevice
---------------------------------------------------------------------------------
----
+---## renoise.SampleLfoModulationDevice
+
+---@class renoise.SampleLfoModulationDevice
+renoise.SampleLfoModulationDevice = {}
+
+---### constants
+
+---@enum renoise.SampleLfoModulationDevice.Mode
+renoise.SampleLfoModulationDevice = {
+  MODE_SIN = 1,
+  MODE_SAW = 2,
+  MODE_PULSE = 3,
+  MODE_RANDOM = 4,
+}
+
 ---### properties
+
+---@class renoise.SampleLfoModulationDevice : renoise.SampleModulationDevice
 ---
 ---LFO mode.
 ---@field mode renoise.SampleLfoModulationDevice.Mode
@@ -494,13 +540,3 @@ function renoise.SampleStepperModulationDevice:remove_point_at(time) end
 ---
 ---Delay.
 ---@field delay renoise.DeviceParameter
-
----------Constants
-
----@enum renoise.SampleLfoModulationDevice.Mode
-renoise.SampleLfoModulationDevice = {
-  MODE_SIN = 1,
-  MODE_SAW = 2,
-  MODE_PULSE = 3,
-  MODE_RANDOM = 4,
-}

--- a/library/renoise/song/instrument/sample_modulation.lua
+++ b/library/renoise/song/instrument/sample_modulation.lua
@@ -1,5 +1,5 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
 ---Please read the introduction at https://github.com/renoise/xrnx/
 ---to get an overview about the complete API, and scripting for

--- a/library/renoise/song/instrument/sample_modulation.lua
+++ b/library/renoise/song/instrument/sample_modulation.lua
@@ -340,28 +340,28 @@ renoise.SampleEnvelopeModulationDevice = {
 ---@field play_mode_observable renoise.Document.Observable
 ---
 ---Envelope length.
----@field length integer Range: (6-1000)
+---@field length integer Range: (6 - 1000)
 ---@field length_observable renoise.Document.Observable
 ---
 ---Loop.
 ---@field loop_mode renoise.SampleEnvelopeModulationDevice.LoopMode
 ---@field loop_mode_observable renoise.Document.Observable
 ---
----@field loop_start integer Range: (1-envelope.length)
+---@field loop_start integer Range: (1 - envelope.length)
 ---@field loop_start_observable renoise.Document.Observable
 ---
----@field loop_end integer Range: (1-envelope.length)
+---@field loop_end integer Range: (1 - envelope.length)
 ---@field loop_end_observable renoise.Document.Observable
 ---
 ---Sustain.
 ---@field sustain_enabled boolean
 ---@field sustain_enabled_observable renoise.Document.Observable
 ---
----@field sustain_position integer Range: (1-envelope.length)
+---@field sustain_position integer Range: (1 - envelope.length)
 ---@field sustain_position_observable renoise.Document.Observable
 ---
 ---Fade amount. (Only applies to volume envelopes)
----@field fade_amount integer Range: (0-4095)
+---@field fade_amount integer Range: (0 - 4095)
 ---@field fade_amount_observable renoise.Document.Observable
 ---
 ---Get all points of the envelope. When setting a new list of points,
@@ -376,9 +376,9 @@ renoise.SampleEnvelopeModulationDevice = {
 ---An envelope point's time.
 ---@field time number Range: (1 - envelope.length)
 ---An envelope point's value.
----@field value number Range: (0.0-1.0)
+---@field value number Range: (0.0 - 1.0)
 ---An envelope point's scaling (used in 'lines' playback mode only - 0.0 is linear).
----@field scaling number Range: (-1.0-1.0)
+---@field scaling number Range: (-1.0 - 1.0)
 
 ---### functions
 
@@ -406,9 +406,9 @@ function renoise.SampleEnvelopeModulationDevice:copy_points_from(other_device) e
 ---@return boolean
 function renoise.SampleEnvelopeModulationDevice:has_point_at(time) end
 
----@param time integer Range: (1-envelope.length)
----@param value number Range: (0.0-1.0)
----@param scaling number? Range: (-1.0-1.0)
+---@param time integer Range: (1 - envelope.length)
+---@param value number Range: (0.0 - 1.0)
+---@param scaling number? Range: (-1.0 - 1.0)
 ---Add a new point value (or replace any existing value) at time.
 function renoise.SampleEnvelopeModulationDevice:add_point_at(time, value, scaling) end
 
@@ -447,11 +447,11 @@ renoise.SampleStepperModulationDevice = {
 ---@field play_mode_observable renoise.Document.Observable
 ---
 ---Step size. -1 is the same as choosing RANDOM
----@field play_step integer Range: (-1-16)
+---@field play_step integer Range: (-1 - 16)
 ---@field play_step_observable renoise.Document.Observable
 ---
 ---Envelope length.
----@field length integer Range: (1-256)
+---@field length integer Range: (1 - 256)
 ---@field length_observable renoise.Document.Observable
 ---
 ---Get all points of the envelope. When setting a new list of points,
@@ -466,9 +466,9 @@ renoise.SampleStepperModulationDevice = {
 ---An envelope point's time.
 ---@field time number Range: (1 - envelope.length)
 ---An envelope point's value.
----@field value number Range: (0.0-1.0)
+---@field value number Range: (0.0 - 1.0)
 ---An envelope point's scaling (used in 'lines' playback mode only - 0.0 is linear).
----@field scaling number Range: (-1.0-1.0)
+---@field scaling number Range: (-1.0 - 1.0)
 
 ---### functions
 

--- a/library/renoise/song/pattern.lua
+++ b/library/renoise/song/pattern.lua
@@ -1,11 +1,8 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----This reference lists all available Lua functions and classes that control
----Renoise's pattern document.
----
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
 ---Renoise in general...
 ---
 
@@ -86,10 +83,12 @@ function renoise.Pattern:track(index) end
 ---@return boolean
 ---@overload fun(self, func: PatternLineChangeCallback): boolean
 function renoise.Pattern:has_line_notifier(func, obj) end
+
 ---@param func PatternLineChangeCallbackWithContext
 ---@param obj table|userdata
 ---@overload fun(self, func: PatternLineChangeCallback): boolean
 function renoise.Pattern:add_line_notifier(func, obj) end
+
 ---@param func PatternLineChangeCallbackWithContext
 ---@param obj table|userdata
 ---@overload fun(self, func: PatternLineChangeCallback): boolean
@@ -102,10 +101,12 @@ function renoise.Pattern:remove_line_notifier(func, obj) end
 ---@overload fun(self, func: PatternLineChangeCallback): boolean
 ---@return boolean
 function renoise.Pattern:has_line_edited_notifier(func, obj) end
+
 ---@param func PatternLineChangeCallbackWithContext
 ---@param obj table|userdata
 ---@overload fun(self, func: PatternLineChangeCallback): boolean
 function renoise.Pattern:add_line_edited_notifier(func, obj) end
+
 ---@param func PatternLineChangeCallbackWithContext
 ---@param obj table|userdata
 ---@overload fun(self, func: PatternLineChangeCallback): boolean

--- a/library/renoise/song/pattern/automation.lua
+++ b/library/renoise/song/pattern/automation.lua
@@ -31,9 +31,9 @@ renoise.PatternTrackAutomation = {
 
 ---Single point within a pattern track automation envelope.
 ---@class EnvelopePoint
----Automation point's time in pattern lines [1 - NUM_LINES_IN_PATTERN].
+---Automation point's time in pattern lines in Range: (1 - NUM_LINES_IN_PATTERN).
 ---@field time number
----Automation point value [0 - 1.0]
+---Automation point value in Range: (0 - 1.0)
 ---@field value number
 ---Automation point scaling. Used in 'lines' playback mode only - 0.0 is linear.
 ---@field scaling number
@@ -54,18 +54,18 @@ renoise.PatternTrackAutomation = {
 ---
 ---**READ-ONLY** Max length (time in lines) of the automation.
 ---Will always fit the patterns length.
----@field length integer [1 - NUM_LINES_IN_PATTERN]
+---@field length integer Range: (1 - NUM_LINES_IN_PATTERN)
 ---
 ---Selection range as visible in the automation editor. always valid.
 ---returns the automation range no selection is present in the UI.
----@field selection_start integer [1 - automation.length + 1]
+---@field selection_start integer Rnage: (1 - automation.length + 1)
 ---@field selection_start_observable renoise.Document.Observable
----@field selection_end integer [1 - automation.length + 1]
+---@field selection_end integer Range: (1  -  automation.length + 1)
 ---@field selection_end_observable renoise.Document.Observable
 ---
 ---Get or set selection range. when setting an empty table, the existing
 ---selection, if any, will be cleared.
----array of two numbers [] OR [1 - automation.length + 1]
+---array of two numbers [] OR Range: (1  -  automation.length + 1)
 ---@field selection_range number[]
 ---@field selection_range_observable renoise.Document.Observable
 ---

--- a/library/renoise/song/pattern/automation.lua
+++ b/library/renoise/song/pattern/automation.lua
@@ -1,11 +1,8 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----This reference lists all available Lua functions and classes that control
----Renoise's pattern track automation document.
----
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
 ---Renoise in general...
 ---
 
@@ -101,12 +98,14 @@ function renoise.PatternTrackAutomation:copy_from(other) end
 ---@param time number
 ---@return boolean
 function renoise.PatternTrackAutomation:has_point_at(time) end
+
 ---Insert a new point, or change an existing one, if a point in
 ---time already exists.
 ---@param time number
 ---@param value number
 ---@param scaling number?
 function renoise.PatternTrackAutomation:add_point_at(time, value, scaling) end
+
 ---Removes a point at the given time. Point must exist.
 ---@param time number
 function renoise.PatternTrackAutomation:remove_point_at(time) end

--- a/library/renoise/song/pattern/line.lua
+++ b/library/renoise/song/pattern/line.lua
@@ -1,11 +1,8 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----This reference lists all available Lua functions and classes that control
----Renoise's pattern track line document.
----
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
 ---Renoise in general...
 ---
 
@@ -76,7 +73,6 @@ function renoise.PatternLine:effect_column(index) end
 ---@param pattern_line renoise.PatternLine
 ---@return string
 function tostring(pattern_line) end
-
 
 --------------------------------------------------------------------------------
 ---renoise.NoteColumn
@@ -153,7 +149,6 @@ function renoise.NoteColumn:copy_from(other) end
 ---Serialize a column.
 ---@param note_column renoise.NoteColumn
 function tostring(note_column) end
-
 
 --------------------------------------------------------------------------------
 ---## renoise.EffectColumn

--- a/library/renoise/song/pattern/track.lua
+++ b/library/renoise/song/pattern/track.lua
@@ -47,14 +47,14 @@ function renoise.PatternTrack:clear() end
 ---@param other renoise.PatternTrack
 function renoise.PatternTrack:copy_from(other) end
 
----Access to a single line by index. Line must be [1-MAX_NUMBER_OF_LINES]).
+---Access to a single line by index. Line must be in Range: (1 - MAX_NUMBER_OF_LINES).
 ---This is a !lot! more efficient than calling the property: lines[index] to
 ---randomly access lines.
 ---@param index integer
 ---@return renoise.PatternLine
 function renoise.PatternTrack:line(index) end
 
----Get a specific line range (index must be [1-Pattern.MAX_NUMBER_OF_LINES])
+---Get a specific line range. Index must be Range: (1 - Pattern.MAX_NUMBER_OF_LINES)
 ---@param index_from integer
 ---@param index_to integer
 ---@return renoise.PatternLine[]

--- a/library/renoise/song/pattern/track.lua
+++ b/library/renoise/song/pattern/track.lua
@@ -1,11 +1,8 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----This reference lists all available Lua functions and classes that control
----Renoise's pattern track document.
----
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
 ---Renoise in general...
 ---
 

--- a/library/renoise/song/pattern_iterator.lua
+++ b/library/renoise/song/pattern_iterator.lua
@@ -1,11 +1,8 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----This reference lists all available Lua functions to iterate through
----pattern content.
----
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
 ---Renoise in general...
 ---
 

--- a/library/renoise/song/sequencer.lua
+++ b/library/renoise/song/sequencer.lua
@@ -1,11 +1,8 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----This reference lists all available Lua functions and classes that control
----Renoise's pattern sequencer document.
----
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
 ---Renoise in general...
 ---
 
@@ -14,7 +11,7 @@
 
 ---Pattern sequencer component of the Renoise song.
 ---@class renoise.PatternSequencer
-renoise.PatternSequencer = { }
+renoise.PatternSequencer = {}
 
 ---### properties
 
@@ -48,10 +45,12 @@ renoise.PatternSequencer = { }
 ---@param sequence_index integer
 ---@param pattern_index integer
 function renoise.PatternSequencer:insert_sequence_at(sequence_index, pattern_index) end
+
 ---Insert an empty, unreferenced pattern at the given position.
 ---@param sequence_index integer
 ---@return integer new_pattern_index
 function renoise.PatternSequencer:insert_new_pattern_at(sequence_index) end
+
 ---Delete an existing position in the sequence. Renoise needs at least one
 ---sequence in the song for playback. Completely removing all sequence positions
 ---is not allowed.
@@ -69,6 +68,7 @@ function renoise.PatternSequencer:pattern(sequence_index) end
 ---@param from_sequence_index integer
 ---@param to_sequence_index integer
 function renoise.PatternSequencer:clone_range(from_sequence_index, to_sequence_index) end
+
 ---Make patterns in the given sequence pos range unique, if needed.
 ---@param from_sequence_index integer
 ---@param to_sequence_index integer
@@ -86,9 +86,11 @@ function renoise.PatternSequencer:sort() end
 ---@param sequence_index integer
 ---@return boolean
 function renoise.PatternSequencer:sequence_is_start_of_section(sequence_index) end
+
 ---@param sequence_index integer
 ---@param is_section boolean
 function renoise.PatternSequencer:set_sequence_is_start_of_section(sequence_index, is_section) end
+
 ---@param sequence_index integer
 ---@return renoise.Document.Observable
 function renoise.PatternSequencer:sequence_is_start_of_section_observable(sequence_index) end
@@ -98,9 +100,11 @@ function renoise.PatternSequencer:sequence_is_start_of_section_observable(sequen
 ---@param sequence_index integer
 ---@return string
 function renoise.PatternSequencer:sequence_section_name(sequence_index) end
+
 ---@param sequence_index integer
 ---@param name string
 function renoise.PatternSequencer:set_sequence_section_name(sequence_index, name) end
+
 ---@param sequence_index integer
 ---@return renoise.Document.Observable
 function renoise.PatternSequencer:sequence_section_name_observable(sequence_index) end
@@ -109,6 +113,7 @@ function renoise.PatternSequencer:sequence_section_name_observable(sequence_inde
 ---@param sequence_index integer
 ---@return boolean
 function renoise.PatternSequencer:sequence_is_part_of_section(sequence_index) end
+
 ---Returns true if the given sequence pos is the end of a section, else false
 ---@param sequence_index integer
 ---@return boolean
@@ -125,6 +130,7 @@ function renoise.PatternSequencer:sequence_sections_changed_observable() end
 ---@param sequence_index integer
 ---@return boolean
 function renoise.PatternSequencer:track_sequence_slot_is_muted(track_index, sequence_index) end
+
 ---@param track_index integer
 ---@param sequence_index integer
 function renoise.PatternSequencer:set_track_sequence_slot_is_muted(track_index, sequence_index, muted) end
@@ -134,6 +140,7 @@ function renoise.PatternSequencer:set_track_sequence_slot_is_muted(track_index, 
 ---@param sequence_index integer
 ---@return boolean
 function renoise.PatternSequencer:track_sequence_slot_is_selected(track_index, sequence_index) end
+
 ---@param track_index integer
 ---@param sequence_index integer
 function renoise.PatternSequencer:set_track_sequence_slot_is_selected(track_index, sequence_index, selected) end

--- a/library/renoise/song/sequencer.lua
+++ b/library/renoise/song/sequencer.lua
@@ -22,7 +22,7 @@ renoise.PatternSequencer = {}
 ---@field keep_sequence_sorted_observable renoise.Document.Observable
 ---
 ---Access to the selected slots in the sequencer. When no selection is present
----`{0, 0}` is returned, else a range between [1 - #sequencer.pattern_sequence]
+---`{0, 0}` is returned, else Range: (1 - #sequencer.pattern_sequence)
 ---@field selection_range integer[]
 ---@field selection_range_observable renoise.Document.Observable
 ---

--- a/library/renoise/song/track.lua
+++ b/library/renoise/song/track.lua
@@ -1,11 +1,8 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----This reference lists all available Lua functions and classes that control
----Renoise's track component in the song.
----
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
 ---Renoise in general...
 ---
 
@@ -43,8 +40,8 @@ renoise.Track = {
 }
 
 ---A table of 3 bytes (ranging from 0 to 255)
----representing the red, green and blue channels of a color.  
----{0xFF, 0xFF, 0xFF} is white  
+---representing the red, green and blue channels of a color.
+---{0xFF, 0xFF, 0xFF} is white
 ---{165, 73, 35} is the red from the Renoise logo
 ---@alias RGBColor {[1] : integer, [2] : integer, [3] : integer}
 
@@ -117,7 +114,7 @@ renoise.Track = {
 ---@field available_devices string[] **READ-ONLY** FX devices this track can handle.
 ---**READ-ONLY** Array of tables containing information about the devices.
 ---@field available_device_infos AudioDeviceInfo[]
----@field devices renoise.AudioDevice[] **READ-ONLY** List of audio DSP FX. 
+---@field devices renoise.AudioDevice[] **READ-ONLY** List of audio DSP FX.
 ---@field devices_observable renoise.Document.ObservableList
 
 ---### functions
@@ -128,9 +125,11 @@ renoise.Track = {
 ---@param device_index integer
 ---@return renoise.AudioDevice
 function renoise.Track:insert_device_at(device_path, device_index) end
+
 ---Delete an existing device in a track. The mixer device at index 1 can not
 ---be deleted from any track.
 function renoise.Track:delete_device_at(device_index) end
+
 ---Swap the positions of two devices in the device chain. The mixer device at
 ---index 1 can not be swapped or moved.
 ---@param device_index1 integer
@@ -145,16 +144,20 @@ function renoise.TrackDevice(device_index) end
 
 ---Uses default mute state from the prefs. Not for the master track.
 function renoise.Track:mute() end
+
 function renoise.Track:unmute() end
+
 function renoise.Track:solo() end
 
 ---Note column mutes. Only valid within (1-track.max_note_columns)
 ---@param column_index integer
 ---@return boolean
 function renoise.Track:column_is_muted(column_index) end
+
 ---@param column_index integer
 ---@return renoise.Document.Observable
 function renoise.Track:column_is_muted_observable(column_index) end
+
 ---@param column_index integer
 ---@param muted boolean
 function renoise.Track:set_column_is_muted(column_index, muted) end
@@ -163,9 +166,11 @@ function renoise.Track:set_column_is_muted(column_index, muted) end
 ---@param column_index integer
 ---@return string
 function renoise.Track:column_name(column_index) end
+
 ---@param column_index integer
 ---@return renoise.Document.Observable
 function renoise.Track:column_name_observable(column_index) end
+
 ---@param column_index integer
 ---@param name string
 function renoise.Track:set_column_name(column_index, name) end
@@ -190,7 +195,7 @@ renoise.GroupTrack = {}
 ---Group track component of a Renoise song.
 ---@class renoise.GroupTrack : renoise.Track
 ---
----**READ-ONLY** All member tracks of this group, including subgroups and 
+---**READ-ONLY** All member tracks of this group, including subgroups and
 ---their tracks.
 ---@field members (renoise.Track|renoise.GroupTrack)[]
 ---

--- a/library/renoise/song/track.lua
+++ b/library/renoise/song/track.lua
@@ -55,7 +55,7 @@ renoise.Track = {
 ---@field name_observable renoise.Document.Observable
 ---@field color RGBColor
 ---@field color_observable renoise.Document.Observable
----@field color_blend number Color blend in percent[0 - 100]
+---@field color_blend number Range: (0 - 100) Color blend in percent
 ---@field color_blend_observable renoise.Document.Observable
 ---
 ---Mute and solo states. Not available for the master track.
@@ -86,7 +86,7 @@ renoise.Track = {
 ---@field output_routing_observable renoise.Document.Observable
 ---
 ---Delay.
----@field output_delay number ms in [-100.0 - 100.0]
+---@field output_delay number Rnage: (-100.0-100.0) in ms 
 ---@field output_delay_observable renoise.Document.Observable
 ---
 ---Pattern editor columns.

--- a/library/renoise/song/transport.lua
+++ b/library/renoise/song/transport.lua
@@ -1,12 +1,8 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----This reference lists all available Lua functions and classes that control
----Renoise's main document - the song - and the corresponding components such as
----Instruments, Tracks, Patterns, and so on.
----
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
 ---Renoise in general...
 ---
 
@@ -46,15 +42,15 @@ renoise.Transport = {
 ---@field playing_observable renoise.Document.Observable
 ---
 ---*READ-ONLY* Old school speed or new LPB timing used?
----With `TIMING_MODEL_SPEED`, tpl is used as speed factor. The lpb property 
+---With `TIMING_MODEL_SPEED`, tpl is used as speed factor. The lpb property
 ---is unused then. With `TIMING_MODEL_LPB`, tpl is used as event rate for effects
 ---only and lpb defines relationship between pattern lines and beats.
 ---@field timing_model renoise.Transport.TimingModel
 ---
 ---BPM, LPB, and TPL
----@field bpm number Beats per Minute [32-999] 
+---@field bpm number Beats per Minute [32-999]
 ---@field bpm_observable renoise.Document.Observable
----@field lpb number Lines per Beat [1-256] 
+---@field lpb number Lines per Beat [1-256]
 ---@field lpb_observable renoise.Document.Observable
 ---@field tpl number Ticks per Line [1-16]
 ---@field tpl_observable renoise.Document.Observable
@@ -142,7 +138,7 @@ renoise.Transport = {
 ---To convert from dB: `renoise.Transport.track_headroom = math.db2lin(dB)`
 ---@field track_headroom number [math.db2lin(-12) - math.db2lin(0)]
 ---@field track_headroom_observable renoise.Document.Observable
---- 
+---
 ---Computer Keyboard Velocity.
 ---@field keyboard_velocity_enabled boolean
 ---@field keyboard_velocity_enabled_observable renoise.Document.Observable
@@ -158,9 +154,11 @@ function renoise.Transport:panic() end
 ---Start playing in song or pattern mode.
 ---@param mode renoise.Transport.PlayMode
 function renoise.Transport:start(mode) end
+
 ---Start playing the currently edited pattern at the given line offset
 ---@param line integer
 function renoise.Transport:start_at(line) end
+
 ---Start playing a the given renoise.SongPos (sequence pos and line)
 ---@param song_pos renoise.SongPos
 function renoise.Transport:start_at(song_pos) end
@@ -171,22 +169,26 @@ function renoise.Transport:stop() end
 ---Immediately start playing at the given sequence position.
 ---@param sequence_pos integer
 function renoise.Transport:trigger_sequence(sequence_pos) end
+
 ---Append the sequence to the scheduled sequence list. Scheduled playback
 ---positions will apply as soon as the currently playing pattern play to end.
 ---@param sequence_pos integer
 function renoise.Transport:add_scheduled_sequence(sequence_pos) end
+
 ---Replace the scheduled sequence list with the given sequence.
 ---@param sequence_pos integer
 function renoise.Transport:set_scheduled_sequence(sequence_pos) end
 
 ---Move the block loop one segment forwards, when possible.
 function renoise.Transport:loop_block_move_forwards() end
+
 ---Move the block loop one segment backwards, when possible.
 function renoise.Transport:loop_block_move_backwards() end
 
 ---Start a new sample recording when the sample dialog is visible,
 ---otherwise stop and finish it.
 function renoise.Transport:start_stop_sample_recording() end
+
 ---Cancel a currently running sample recording when the sample dialog
 ---is visible, otherwise do nothing.
 function renoise.Transport:cancel_sample_recording() end

--- a/library/renoise/song/transport.lua
+++ b/library/renoise/song/transport.lua
@@ -48,20 +48,20 @@ renoise.Transport = {
 ---@field timing_model renoise.Transport.TimingModel
 ---
 ---BPM, LPB, and TPL
----@field bpm number Beats per Minute [32-999]
+---@field bpm number Range: (32 - 999) Beats per Minute
 ---@field bpm_observable renoise.Document.Observable
----@field lpb number Lines per Beat [1-256]
+---@field lpb number Range: (1 - 256) Lines per Beat
 ---@field lpb_observable renoise.Document.Observable
----@field tpl number Ticks per Line [1-16]
+---@field tpl number  Range: (1 - 16) Ticks per Line
 ---@field tpl_observable renoise.Document.Observable
 ---
 ---Playback position
 ---@field playback_pos renoise.SongPos
----@field playback_pos_beats number Song position in beats [0 - song_end_beats]
+---@field playback_pos_beats number Range: (0 - song_end_beats) Song position in beats
 ---
 ---Edit position
 ---@field edit_pos renoise.SongPos
----@field edit_pos_beats number Song position in beats [0 - song_end_beats]
+---@field edit_pos_beats number Range: (0 - song_end_beats) Song position in beats
 ---
 ---Song length
 ---@field song_length renoise.SongPos **READ-ONLY**
@@ -71,47 +71,47 @@ renoise.Transport = {
 ---@field loop_start renoise.SongPos **READ-ONLY**
 ---@field loop_end renoise.SongPos **READ-ONLY**
 ---@field loop_range renoise.SongPos[] {loop start, loop end}
----@field loop_start_beats number **READ-ONLY** [0 - song_end_beats]
----@field loop_end_beats number **READ-ONLY** [0 - song_end_beats]
+---@field loop_start_beats number **READ-ONLY** Range: (0 - song_end_beats)
+---@field loop_end_beats number **READ-ONLY** Range: (0 - song_end_beats)
 ---@field loop_range_beats number[] {loop start beats, loop end beats}
 ---
----@field loop_sequence_start number **READ-ONLY** 0 or [1 - sequence length]
----@field loop_sequence_end number **READ-ONLY** 0 or [1 - sequence length]
----@field loop_sequence_range number[] {} or [sequence start, sequence end]
+---@field loop_sequence_start number **READ-ONLY** 0 or Range: (1  -  sequence length)
+---@field loop_sequence_end number **READ-ONLY** 0 or Range: (1  -  sequence length)
+---@field loop_sequence_range number[] {} or Range(sequence start, sequence end)
 ---
 ---@field loop_pattern boolean Pattern Loop On/Off
 ---@field loop_pattern_observable renoise.Document.Observable
 ---
 ---@field loop_block_enabled boolean Block Loop On/Off
 ---@field loop_block_start_pos renoise.SongPos Start of block loop
----@field loop_block_range_coeff number [2 - 16]
+---@field loop_block_range_coeff number Range: (2 - 16)
 ---
 ---Edit modes
 ---@field edit_mode boolean
 ---@field edit_mode_observable renoise.Document.Observable
----@field edit_step integer [0 - 64]
+---@field edit_step integer Range: (0 - 64)
 ---@field edit_step_observable renoise.Document.Observable
----@field octave integer [0 - 8]
+---@field octave integer Range: (0 - 8)
 ---@field octave_observable renoise.Document.Observable
 ---
 ---Metronome
 ---@field metronome_enabled boolean
 ---@field metronome_enabled_observable renoise.Document.Observable
----@field metronome_beats_per_bar integer [1 - 16]
+---@field metronome_beats_per_bar integer Range: (1 - 16)
 ---@field metronome_beats_per_bar_observable renoise.Document.Observable
----@field metronome_lines_per_beat integer [1-256 or 0 = songs current LPB]
+---@field metronome_lines_per_beat integer Range: (1 - 256) or 0 = songs current LPB
 ---@field metronome_lines_per_beat_observable renoise.Document.Observable
 ---
 ---Metronome precount
 ---@field metronome_precount_enabled boolean
 ---@field metronome_precount_enabled_observable renoise.Document.Observable
----@field metronome_precount_bars integer [1 - 4]
+---@field metronome_precount_bars integer Range: ([1 - 4)
 ---@field metronome_precount_bars_observable renoise.Document.Observable
 ---
 ---Quantize
 ---@field record_quantize_enabled boolean
 ---@field record_quantize_enabled_observable renoise.Document.Observable
----@field record_quantize_lines integer [1 - 32]
+---@field record_quantize_lines integer Range: (1 - 32)
 ---@field record_quantize_lines_observable renoise.Document.Observable
 ---
 ---Record parameter
@@ -129,21 +129,21 @@ renoise.Transport = {
 ---Groove. (aka Shuffle)
 ---@field groove_enabled boolean
 ---@field groove_enabled_observable renoise.Document.Observable
----@field groove_amounts number[] table with 4 numbers [0 - 1]
+---@field groove_amounts number[] table with 4 numbers in Range: (0 - 1)
 ---Attach notifiers that will be called as soon as any groove value changed.
 ---@field groove_assignment_observable renoise.Document.Observable
 ---
 ---Global Track Headroom
 ---To convert to dB: `dB = math.lin2db(renoise.Transport.track_headroom)`
 ---To convert from dB: `renoise.Transport.track_headroom = math.db2lin(dB)`
----@field track_headroom number [math.db2lin(-12) - math.db2lin(0)]
+---@field track_headroom number Range: (math.db2lin(-12) - math.db2lin(0))
 ---@field track_headroom_observable renoise.Document.Observable
 ---
 ---Computer Keyboard Velocity.
 ---@field keyboard_velocity_enabled boolean
 ---@field keyboard_velocity_enabled_observable renoise.Document.Observable
 ---Will return the default value of 127 when keyboard_velocity_enabled == false.
----@field keyboard_velocity integer [0 - 127]
+---@field keyboard_velocity integer Range: (0 - 127)
 ---@field keyboard_velocity_observable renoise.Document.Observable
 
 ---### functions

--- a/library/renoise/tool.lua
+++ b/library/renoise/tool.lua
@@ -1,21 +1,20 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----This reference lists Lua functions and classes to manage Renoise XRNX 
----"scripting tool" packages. 
----
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for 
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
 ---Renoise in general...
 ---
----Also have a look at the com.renoise.ExampleTool.xrnx for guided examples.
+---Also have a look at the "com.renoise.ExampleTool.xrnx" tool for guided examples.
+---This tool is included in the scripting dev started pack at
+---https://github.com/renoise/xrnx/
 ---
 
 --------------------------------------------------------------------------------
 ---## renoise.ScriptingTool
 
 ---The scripting tool interface allows your tool to interact with Renoise by
----injecting or creating menu entries and keybindings into Renoise; or by 
+---injecting or creating menu entries and keybindings into Renoise; or by
 ---attaching it to some common tool related notifiers.
 ---@class renoise.ScriptingTool
 ---
@@ -23,7 +22,7 @@
 ---@field bundle_path string
 ---
 ---Invoked when the tool finished loading/initializing and no errors happened.
----When the tool has preferences, they are loaded here as well when the 
+---When the tool has preferences, they are loaded here as well when the
 ---notification fires, but 'renoise.song()' may not yet be available.
 ---
 ---See also 'renoise.tool().app_new_document_observable'.
@@ -213,7 +212,7 @@ function renoise.ScriptingTool:remove_menu_entry(entry_name) end
 ---+ "DSPs Chain"
 ---+ "Instrument Box"
 ---+ "Mixer"
----+ "Pattern Editor" 
+---+ "Pattern Editor"
 ---+ "Pattern Matrix"
 ---+ "Pattern Sequencer"
 ---+ "Sample Editor"
@@ -227,7 +226,7 @@ function renoise.ScriptingTool:remove_menu_entry(entry_name) end
 ---@field invoke fun(repeated: boolean)
 
 ---Returns true when the given keybinging already exists, otherwise false.
----@param keybinding_name string Name of the binding e.g. "Global:My Tool:My Action" 
+---@param keybinding_name string Name of the binding e.g. "Global:My Tool:My Action"
 ---@return boolean
 function renoise.ScriptingTool:has_keybinding(keybinding_name) end
 
@@ -236,7 +235,7 @@ function renoise.ScriptingTool:has_keybinding(keybinding_name) end
 function renoise.ScriptingTool:add_keybinding(keybinding) end
 
 ---Remove a previously added key binding by specifying its name and path.
----@param keybinding_name string Name of the binding e.g. "Global:My Tool:My Action" 
+---@param keybinding_name string Name of the binding e.g. "Global:My Tool:My Action"
 function renoise.ScriptingTool:remove_keybinding(keybinding_name) end
 
 -------------------------------------------------------------------------------
@@ -294,7 +293,7 @@ function renoise.ScriptingTool.MidiMessage:is_abs_value() end
 ---@field invoke fun(message: renoise.ScriptingTool.MidiMessage)
 
 ---Returns true when the given mapping already exists, otherwise false.
----@param midi_mapping_name string Name of the mapping. 
+---@param midi_mapping_name string Name of the mapping.
 ---@return boolean
 function renoise.ScriptingTool:has_midi_mapping(midi_mapping_name) end
 
@@ -303,7 +302,7 @@ function renoise.ScriptingTool:has_midi_mapping(midi_mapping_name) end
 function renoise.ScriptingTool:add_midi_mapping(midi_mapping) end
 
 ---Remove a previously added midi mapping by specifying its name.
----@param midi_mapping_name string Name of the mapping. 
+---@param midi_mapping_name string Name of the mapping.
 function renoise.ScriptingTool:remove_midi_mapping(midi_mapping_name) end
 
 -------------------------------------------------------------------------------
@@ -323,7 +322,7 @@ function renoise.ScriptingTool:remove_midi_mapping(midi_mapping_name) end
 ---
 ---@class ToolFileImportHook
 ---In which disk browser category the file type shows up.
----One of 
+---One of
 ---@field category FileHookCategory
 ---A list of strings, file extensions, that will invoke your hook, like for
 ---example {"txt", "s_wave"}

--- a/library/renoise/tool.lua
+++ b/library/renoise/tool.lua
@@ -242,7 +242,7 @@ function renoise.ScriptingTool:remove_keybinding(keybinding_name) end
 
 ---MIDI message as passed to the `invoke` callback in tool midi_mappings.
 ---@class renoise.ScriptingTool.MidiMessage
----[0 - 127] for abs values, [-63 - 63] for relative values
+---Range: (0S - 127) for abs values, Range: (-63 - 63) for relative values
 ---valid when `is_rel_value()` or `is_abs_value()` returns true, else undefined
 ---@field int_value integer|nil
 ---valid [true OR false] when `is_switch()` returns true, else undefined

--- a/library/renoise/view_builder.lua
+++ b/library/renoise/view_builder.lua
@@ -569,7 +569,7 @@ renoise.Views.Button = {}
 ---unpressed button's background will be drawn in the specified color.
 ---A text color is automatically selected to make sure its always visible.
 ---Set color {0,0,0} to enable the theme colors for the button again.
----@field color RGBColor Range: (0-255)
+---@field color RGBColor Range: (0 - 255)
 ---
 ---Valid in the construction table only: set up a click notifier.
 ---@field pressed function

--- a/library/renoise/view_builder.lua
+++ b/library/renoise/view_builder.lua
@@ -1,17 +1,14 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----This reference lists all "View" related functions in the API. View means
----classes and functions that are used to build custom GUIs; GUIs for your
----scripts in Renoise.
----
----Please read the `Introduction.md` in the Renoise scripting Documentation
----folder first to get an overview about the complete API, and scripting for
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
 ---Renoise in general...
 ---
 ---For a small tutorial and more details about how to create and use views,
----have a look at the "com.renoise.ExampleToolGUI.xrnx" tool. This tool is
----included in the scripting dev started pack at <http://scripting.renoise.com>
+---have a look at the "com.renoise.ExampleToolGUI.xrnx" tool.
+---This tool is included in the scripting dev started pack at
+---https://github.com/renoise/xrnx/
 ---
 
 --------------------------------------------------------------------------------

--- a/library/renoise/view_builder.lua
+++ b/library/renoise/view_builder.lua
@@ -1270,6 +1270,9 @@ renoise.ViewBuilder.DEFAULT_DIALOG_BUTTON_HEIGHT = 22
 ---Creates a column view with `margin = 1` and adds two text views to the column.
 ---@class renoise.ViewBuilder
 ---
+---Construct a new view builder object.
+---@overload fun():renoise.ViewBuilder
+---
 ---Table of views, which got registered via the "id" property
 ---View id is the table key, the table's value is the view's object.
 ---

--- a/library/renoise/view_builder.lua
+++ b/library/renoise/view_builder.lua
@@ -14,9 +14,6 @@
 ---included in the scripting dev started pack at <http://scripting.renoise.com>
 ---
 
---TODO annotate add/remove_notifier inputs properly
---TODO add separate view builder properties objects?
-
 --------------------------------------------------------------------------------
 ---## introduction
 

--- a/library/renoise/view_builder.lua
+++ b/library/renoise/view_builder.lua
@@ -1,90 +1,100 @@
+---@meta
+---Do not try to execute this file. It's just a type definition file.
+---
+---This reference lists all "View" related functions in the API. View means
+---classes and functions that are used to build custom GUIs; GUIs for your
+---scripts in Renoise.
+---
+---Please read the `Introduction.md` in the Renoise scripting Documentation
+---folder first to get an overview about the complete API, and scripting for
+---Renoise in general...
+---
+---For a small tutorial and more details about how to create and use views,
+---have a look at the "com.renoise.ExampleToolGUI.xrnx" tool. This tool is
+---included in the scripting dev started pack at <http://scripting.renoise.com>
+---
+
 --TODO annotate add/remove_notifier inputs properly
-
---[[============================================================================
-Renoise ViewBuilder API Reference
-============================================================================]]--
-
---[[
-
-This reference lists all "View" related functions in the API. View means
-classes and functions that are used to build custom GUIs; GUIs for your
-scripts in Renoise.
-
-Please read the INTRODUCTION first to get an overview about the complete
-API, and scripting for Renoise in general...
-
-For a small tutorial and more details about how to create and use views, have
-a look at the "com.renoise.ExampleToolGUI.xrnx" tool. This tool is included in
-the scripting dev started pack at <http://scripting.renoise.com>
-
-Do not try to execute this file. It uses a .lua extension for markup only.
-
-]]--
-
-
----### introduction
--- Currently there are two ways to to create custom views:
---
--- Shows a modal dialog with a title, custom content and custom button labels:
---renoise.app():show_custom_prompt(
---  title, content_view, {button_labels} [, key_handler_func, key_handler_options])
---  -> [pressed button]
-
--- _(and)_ Shows a non modal dialog, a floating tool window, with custom
--- content:
---renoise.app():show_custom_dialog(
---  title, content_view [, key_handler_func, key_handler_options])
---  -> [dialog object]
-
--- key_handler_func is optional. When defined, it should point to a function
--- with the signature noted below. "key" is a table with the fields:
--- > key = {  
--- >   name,      -- name of the key, like 'esc' or 'a' - always valid  
--- >   modifiers, -- modifier states. 'shift + control' - always valid  
--- >   character, -- character representation of the key or nil  
--- >   note,      -- virtual keyboard piano key value (starting from 0) or nil  
--- >   state,     -- optional (see below) - is the key getting pressed or released?
--- >   repeated,  -- optional (see below) - true when the key is soft repeated (held down)
--- > }
--- 
--- The "repeated" field will not be present when 'send_key_repeat' in the key 
--- handler options is set to false. The "state" field only is present when the
--- 'send_key_release' in the key handler options is set to true. So by default only 
--- key presses are send to the key handler.
---
--- key_handler_options is an optional table with the fields:
--- > options = { 
--- >   send_key_repeat=true OR false   -- by default true
--- >   send_key_release=true OR false  -- by default false
--- > }
--- >
--- Returned "dialog" is a reference to the dialog the keyhandler is running on.
---
---     function my_keyhandler_func(dialog, key) end
---
--- When no key handler is specified, the Escape key is used to close the dialog.
--- For prompts, the first character of the button labels is used to invoke
--- the corresponding button.
--- 
--- When returning the passed key from the key-handler function, the
--- key will be passed back to Renoise's key event chain, in order to allow
--- processing global Renoise key-bindings from your dialog. This will not work
--- for modal dialogs. This also only applies to global shortcuts in Renoise,
--- because your dialog will steal the focus from all other Renoise views such as
--- the Pattern Editor, etc.
-
-
---==============================================================================
----@class renoise.Views
-renoise.Views = {}
---==============================================================================
+--TODO add separate view builder properties objects?
 
 --------------------------------------------------------------------------------
+---## introduction
+
+--- Currently there are two ways to to create custom views:
+---
+---Shows a modal dialog with a title, custom content and custom button labels:
+---```lua
+---renoise.app():show_custom_prompt(
+--- title, content_view, {button_labels} [, key_handler_func, key_handler_options])
+--- --> [pressed button]
+---```
+---
+---*(and)* Shows a non modal dialog, a floating tool window, with custom
+---content:
+---```lua
+---renoise.app():show_custom_dialog(
+--- title, content_view [, key_handler_func, key_handler_options])
+--- --> [dialog object]
+---```
+---
+---key_handler_func is optional. When defined, it should point to a function
+---with the signature noted below. "key" is a table with the fields:
+---```lua
+---key = {
+---  name,      -- name of the key, like 'esc' or 'a' - always valid
+---  modifiers, -- modifier states. 'shift + control' - always valid
+---  character, -- character representation of the key or nil
+---  note,      -- virtual keyboard piano key value (starting from 0) or nil
+---  state,     -- optional (see below) - is the key getting pressed or released?
+---  repeated,  -- optional (see below) - true when the key is soft repeated (held down)
+---}
+---```
+---
+---The "repeated" field will not be present when 'send_key_repeat' in the key
+---handler options is set to false. The "state" field only is present when the
+---'send_key_release' in the key handler options is set to true. So by default only
+---key presses are send to the key handler.
+---
+---key_handler_options is an optional table with the fields:
+---```lua
+---options = {
+---  send_key_repeat=true OR false   -- by default true
+---  send_key_release=true OR false  -- by default false
+---}
+---```
+---Returned "dialog" is a reference to the dialog the keyhandler is running on.
+---
+---`function my_keyhandler_func(dialog, key) end`
+
+---When no key handler is specified, the Escape key is used to close the dialog.
+---For prompts, the first character of the button labels is used to invoke
+---the corresponding button.
+---
+---When returning the passed key from the key-handler function, the
+---key will be passed back to Renoise's key event chain, in order to allow
+---processing global Renoise key-bindings from your dialog. This will not work
+---for modal dialogs. This also only applies to global shortcuts in Renoise,
+---because your dialog will steal the focus from all other Renoise views such as
+---the Pattern Editor, etc.
+
+--------------------------------------------------------------------------------
+---## renoise.Views
+
+---@class renoise.Views
+renoise.Views = {}
+
+--------------------------------------------------------------------------------
+---## renoise.Views.View
+
+---@class renoise.Views.View
+renoise.Views.View = {}
+
+---### properties
+
 ---View is the base class for all child views. All View properties can be
 ---applied to any of the following specialized views.
 ---@class renoise.Views.View
---------------------------------------------------------------------------------
----### properties
+---
 ---Set visible to false to hide a view (make it invisible without removing
 ---it). Please note that view.visible will also return false when any of its
 ---parents are invisible (when its implicitly invisible).
@@ -113,11 +123,16 @@ function renoise.Views.View:add_child(child) end
 function renoise.Views.View:remove_child(child) end
 
 --------------------------------------------------------------------------------
+---## renoise.Views.Control
+
+---@class renoise.Views.Control
+renoise.Views.Control = {}
+
+---### properties
+
 ---Control is the base class for all views which let the user change a value or
 ---some "state" from the UI.
 ---@class renoise.Views.Control : renoise.Views.View
----
----### properties
 ---
 ---Instead of making a control invisible, you can also make it inactive.
 ---Deactivated controls will still be shown, and will still show their
@@ -134,15 +149,20 @@ function renoise.Views.View:remove_child(child) end
 ---@field midi_mapping string
 
 --------------------------------------------------------------------------------
+---## renoise.Views.Rack
+
+---@class renoise.Views.Rack
+renoise.Views.Rack = {}
+
+---### properties
+
 ---@see renoise.ViewBuilder.column
 ---@see renoise.ViewBuilder.row
 ---A Rack has no content on its own. It only stacks child views. Either
 ---vertically (ViewBuilder.column) or horizontally (ViewBuilder.row). It allows
 ---you to create view layouts.
----@class renoise.Views.Rack : renoise.Views.View 
---------------------------------------------------------------------------------
 ---
----### properties
+---@class renoise.Views.Rack : renoise.Views.View
 ---
 ---Set the "borders" of the rack (left, right, top and bottom inclusively)
 ---@field margin number Default: 0 (no borders)
@@ -153,12 +173,12 @@ function renoise.Views.View:remove_child(child) end
 ---
 ---Setup a background style for the rack. Available styles are:
 ---@alias RackStyle
----| '"invisible"' # no background
----| '"plain"'     # undecorated, single coloured background
----| '"border"'    # same as plain, but with a bold nested border
----| '"body"'      # main "background" style, as used in dialog backgrounds
----| '"panel"'     # alternative "background" style, beveled
----| '"group"'     # background for "nested" groups within body
+---| "invisible" # no background
+---| "plain"     # undecorated, single coloured background
+---| "border"    # same as plain, but with a bold nested border
+---| "body"      # main "background" style, as used in dialog backgrounds
+---| "panel"     # alternative "background" style, beveled
+---| "group"     # background for "nested" groups within body
 ---
 ---@field style RackStyle Default: "invisible"
 ---
@@ -169,8 +189,14 @@ function renoise.Views.View:remove_child(child) end
 ---as a child view size changes or new children are added.
 ---@field uniform boolean Default: false
 
-
 --------------------------------------------------------------------------------
+---## renoise.Views.Aligner
+
+---@class renoise.Views.Aligner
+renoise.Views.Aligner = {}
+
+---### properties
+
 ---@see renoise.ViewBuilder.horizontal_aligner
 ---@see renoise.ViewBuilder.vertical_aligner
 ---Just like a Rack, the Aligner shows no content on its own. It just aligns
@@ -179,9 +205,8 @@ function renoise.Views.View:remove_child(child) end
 ---(including spacing & margins).
 ---To make use of modes like "center", you manually have to setup a size that
 ---is bigger than the sum of the child sizes.
----@class renoise.Views.Aligner : renoise.Views.View
 ---
----### properties
+---@class renoise.Views.Aligner : renoise.Views.View
 ---
 ---Setup "borders" for the aligner (left, right, top and bottom inclusively)
 ---@field margin number Default: 0 (no borders)
@@ -191,30 +216,36 @@ function renoise.Views.View:remove_child(child) end
 ---@field spacing number Default: 0 (no spacing)
 ---
 ---@alias AlignerAlignment
----| '"left"'       # align from left to right (for horizontal_aligner only)
----| '"right"'      # align from right to left (for horizontal_aligner only)
----| '"top"'        # align from top to bottom (for vertical_aligner only)
----| '"bottom"'     # align from bottom to top (for vertical_aligner only)
----| '"center"'     # center all views
----| '"justify"'    # keep outer views at the borders, distribute the rest
----| '"distribute"' # equally distributes views over the aligners width/height
+---| "left"       # align from left to right (for horizontal_aligner only)
+---| "right"      # align from right to left (for horizontal_aligner only)
+---| "top"        # align from top to bottom (for vertical_aligner only)
+---| "bottom"     # align from bottom to top (for vertical_aligner only)
+---| "center"     # center all views
+---| "justify"    # keep outer views at the borders, distribute the rest
+---| "distribute" # equally distributes views over the aligners width/height
 ---
 ---Default: "left" (for horizontal_aligner) "top" (for vertical_aligner)
----@field mode AlignerAlignment 
+---@field mode AlignerAlignment
 
 
 -----------------------------------------------------------------------------
+---## renoise.Views.Text
+
+---@class renoise.Views.Text
+renoise.Views.Text = {}
+
+---### properties
 
 ---@see renoise.ViewBuilder.text
 ---Shows a "static" text string. Static just means that its not linked, bound
----to some value and has no notifiers. The text can not be edited by the user. 
----Nevertheless you can of course change the text at run-time with the "text" 
+---to some value and has no notifiers. The text can not be edited by the user.
+---Nevertheless you can of course change the text at run-time with the "text"
 ---property.
+---```md
+---  Text, Bla 1
+---```
 ---@see renoise.Views.TextField for texts that can be edited by the user.
 ---@class renoise.Views.Text : renoise.Views.View
------------------------------------------------------------------------------
----
----### properties
 ---
 ---Get/set the text that should be displayed. Setting a new text will resize
 ---the view in order to make the text fully visible (expanding only).
@@ -222,52 +253,56 @@ function renoise.Views.View:remove_child(child) end
 ---
 ---Get/set the style that the text should be displayed with.
 ---@alias FontStyle
----| '"normal"'
----| '"big"'
----| '"bold"'
----| '"italic"'
----| '"mono"'
+---| "normal"
+---| "big"
+---| "bold"
+---| "italic"
+---| "mono"
 ---
 ---@field font FontStyle Default: "normal"
 ---
 ---Get/set the color style the text should be displayed with.
 ---@alias TextStyle
----| '"normal"'
----| '"strong"'
----| '"disabled"'
+---| "normal"
+---| "strong"
+---| "disabled"
 ---
 ---@field style TextStyle Default: "normal"
 ---
 ---Setup the text's alignment. Applies only when the view's size is larger than
 ---the needed size to draw the text
 ---@alias TextAlignment
----| '"left"'
----| '"right"'
----| '"center"'
+---| "left"
+---| "right"
+---| "center"
 ---
 ---@field align TextAlignment Default: "left"
 
 
 --------------------------------------------------------------------------------
+---## renoise.Views.MultiLineText
+
+---@class renoise.Views.MultiLineText
+renoise.Views.MultiLineText = {}
+
+---### properties
+
 ---@see renoise.ViewBuilder.multiline_textfield
 ---Shows multiple lines of text, auto-formatting and auto-wrapping paragraphs
 ---into lines. Size is not automatically set. As soon as the text no longer fits
 ---into the view, a vertical scroll bar will be shown.
+---
 ---@see renoise.Views.MultiLineTextField for multiline texts that can be edited
 ---by the user.
----
----. +--------------+-+
----. | Text, Bla 1  |+|
----. | Text, Bla 2  | |
----. | Text, Bla 3  | |
----. | Text, Bla 4  |+|
----. +--------------+-+
----
----![MultiLineText](___REPLACE_URL___/MultiLineText.png)
+---```md
+--- +--------------+-+
+--- | Text, Bla 1  |+|
+--- | Text, Bla 2  | |
+--- | Text, Bla 3  | |
+--- | Text, Bla 4  |+|
+--- +--------------+-+
+---```
 ---@class renoise.Views.MultiLineText : renoise.Views.View
---------------------------------------------------------------------------------
----
----### properties
 ---
 ---Get/set the text that should be displayed on a single line. Newlines
 ---(Windows, Mac or Unix styled newlines) in the text can be used to create
@@ -282,9 +317,9 @@ function renoise.Views.View:remove_child(child) end
 ---
 ---Setup the text view's background:
 ---@alias TextBackgroundStyle
----| '"body"'    # simple text color with no background  
----| '"strong"'  # stronger text color with no background  
----| '"border"'  # text on a bordered background
+---| "body"    # simple text color with no background
+---| "strong"  # stronger text color with no background
+---| "border"  # text on a bordered background
 ---
 ---@field style TextBackgroundStyle Default: "body"
 
@@ -304,20 +339,22 @@ function renoise.Views.MultiLineText:add_line(text) end
 ---Clear the whole text, same as multiline_text.text="".
 function renoise.Views.MultiLineText:clear() end
 
-
 --------------------------------------------------------------------------------
+---## renoise.Views.TextField
+
+---@class renoise.Views.TextField
+renoise.Views.TextField = {}
+
+---### properties
+
 ---@see renoise.ViewBuilder.textfield
 ---Shows a text string that can be clicked and edited by the user.
----
----. +----------------+
----. | Editable Te|xt |
----. +----------------+
----
----![TextField](___REPLACE_URL___/TextField.png)
+---```md
+--- +----------------+
+--- | Editable Te|xt |
+--- +----------------+
+---```
 ---@class renoise.Views.TextField : renoise.Views.View
---------------------------------------------------------------------------------
----
----### properties
 ---
 ---When false, text is displayed but can not be entered/modified by the user.
 ---@field active boolean Default: true
@@ -360,22 +397,25 @@ function renoise.Views.TextField:add_notifier(notifier) end
 function renoise.Views.TextField:remove_notifier(notifier) end
 
 --------------------------------------------------------------------------------
+---## renoise.Views.MultiLineTextField
+
+---@class renoise.Views.MultiLineTextField
+renoise.Views.MultiLineTextField = {}
+
+---### properties
+
 ---@see renoise.ViewBuilder.multiline_textfield
 ---Shows multiple text lines of text, auto-wrapping paragraphs into lines. The
 ---text can be edited by the user.
----
----. +--------------------------+-+
----. | Editable Te|xt.          |+|
----. |                          | |
----. | With multiple paragraphs | |
----. | and auto-wrapping        |+|
----. +--------------------------+-+
----
----![MultiLineTextField](___REPLACE_URL___/MultiLineTextField.png)
+---```md
+--- +--------------------------+-+
+--- | Editable Te|xt.          |+|
+--- |                          | |
+--- | With multiple paragraphs | |
+--- | and auto-wrapping        |+|
+--- +--------------------------+-+
+---```
 ---@class renoise.Views.MultiLineTextField : renoise.Views.View
---------------------------------------------------------------------------------
----
----### properties
 ---
 ---When false, text is displayed but can not be entered/modified by the user.
 ---@field active boolean Default: true
@@ -436,8 +476,14 @@ function renoise.Views.MultiLineTextField:add_line(text) end
 ---Clear the whole text.
 function renoise.Views.MultiLineTextField:clear() end
 
-
 --------------------------------------------------------------------------------
+---## renoise.Views.Bitmap
+
+---@class renoise.Views.Bitmap
+renoise.Views.Bitmap = {}
+
+---### properties
+
 ---@see renoise.ViewBuilder.bitmap
 ---Draws a bitmap, or a draws a bitmap which acts like a button (as soon as a
 ---notifier is specified). The notifier is called when clicking the mouse
@@ -445,29 +491,25 @@ function renoise.Views.MultiLineTextField:clear() end
 ---bitmap is automatically recolored to match the current theme's colors. Mouse
 ---hover is also enabled when notifies are present, to show that the bitmap can
 ---be clicked.
----
----.        *
----.       ***
----.    +   *
----.   / \
----.  +---+
----.  | O |  o
----.  +---+  |
----. ||||||||||||
----
----![Bitmap](___REPLACE_URL___/Bitmap.png)
----@class renoise.Views.Bitmap : renoise.Views.Control 
---------------------------------------------------------------------------------
----
----### properties
+---```md
+---        *
+---       ***
+---    +   *
+---   / \
+---  +---+
+---  | O |  o
+---  +---+  |
+--- ||||||||||||
+---```
+---@class renoise.Views.Bitmap : renoise.Views.Control
 ---
 ---Setup how the bitmap should be drawn, recolored. Available modes are:
 ---@alias View.Bitmap.Mode
----| '"plain"'        # bitmap is drawn as is, no recoloring is done  
----| '"transparent"'  # same as plain, but black pixels will be fully transparent  
----| '"button_color"' # recolor the bitmap, using the theme's button color  
----| '"body_color"'   # same as 'button_back' but with body text/back color  
----| '"main_color"'   # same as 'button_back' but with main text/back colors
+---| "plain"        # bitmap is drawn as is, no recoloring is done
+---| "transparent"  # same as plain, but black pixels will be fully transparent
+---| "button_color" # recolor the bitmap, using the theme's button color
+---| "body_color"   # same as 'button_back' but with body text/back color
+---| "main_color"   # same as 'button_back' but with main text/back colors
 ---
 ---@field mode string Default: "plain"
 ---
@@ -496,19 +538,22 @@ function renoise.Views.Bitmap:add_notifier(notifier) end
 function renoise.Views.Bitmap:remove_notifier(notifier) end
 
 --------------------------------------------------------------------------------
+---## renoise.Views.Button
+
+---@class renoise.Views.Button : renoise.Views.Control
+renoise.Views.Button = {}
+
+---### properties
+
 ---@see renoise.ViewBuilder.button
 ---A simple button that calls a custom notifier function when clicked.
 ---Supports text or bitmap labels.
----
----. +--------+
----. | Button |
----. +--------+
----
----![Button](___REPLACE_URL___/Button.png)
+---```md
+--- +--------+
+--- | Button |
+--- +--------+
+---```
 ---@class renoise.Views.Button : renoise.Views.Control
---------------------------------------------------------------------------------
----
----### properties
 ---
 ---The text label of the button
 ---@field text string Default: ""
@@ -527,8 +572,8 @@ function renoise.Views.Bitmap:remove_notifier(notifier) end
 ---@field bitmap string
 ---
 ---Table of RGB values like {0xff,0xff,0xff} -> white. When set, the
----unpressed button's background will be drawn in the specified color.  
----A text color is automatically selected to make sure its always visible.  
+---unpressed button's background will be drawn in the specified color.
+---A text color is automatically selected to make sure its always visible.
 ---Set color {0,0,0} to enable the theme colors for the button again.
 ---@field color RGBColor Range: (0-255)
 ---
@@ -559,21 +604,23 @@ function renoise.Views.Button:remove_pressed_notifier(notifier) end
 ---@param notifier function
 function renoise.Views.Button:remove_released_notifier(notifier) end
 
-
 --------------------------------------------------------------------------------
+---## renoise.Views.CheckBox
+
+---@class renoise.Views.CheckBox
+renoise.Views.CheckBox = {}
+
+---### properties
+
 ---@see renoise.ViewBuilder.checkbox
 ---A single button with a checkbox bitmap, which can be used to toggle
 ---something on/off.
----
----. +----+
----. | _/ |
----. +----+
----
----![CheckBox](___REPLACE_URL___/CheckBox.png)
+---```md
+--- +----+
+--- | _/ |
+--- +----+
+---```
 ---@class renoise.Views.CheckBox : renoise.Views.Control
---------------------------------------------------------------------------------
----
----### properties
 ---
 ---The current state of the checkbox, expressed as boolean.
 ---@field value boolean Default: false
@@ -600,19 +647,22 @@ function renoise.Views.CheckBox:add_notifier(notifier) end
 function renoise.Views.CheckBox:remove_notifier(notifier) end
 
 --------------------------------------------------------------------------------
+---## renoise.Views.Switch
+
+---@class renoise.Views.Switch : renoise.Views.Control
+renoise.Views.Switch = {}
+
+---### properties
+
 ---@see renoise.ViewBuilder.switch
 ---A set of horizontally aligned buttons, where only one button can be enabled
 ---at the same time. Select one of multiple choices, indices.
----
----. +-----------+------------+----------+
----. | Button A  | +Button+B+ | Button C |
----. +-----------+------------+----------+
----
----![Switch](___REPLACE_URL___/Switch.png)
+---```md
+--- +-----------+------------+----------+
+--- | Button A  | +Button+B+ | Button C |
+--- +-----------+------------+----------+
+---```
 ---@class renoise.Views.Switch : renoise.Views.Control
---------------------------------------------------------------------------------
----
----### properties
 ---
 ---Get/set the currently shown button labels.
 ---@field items string[] size must be >= 2
@@ -635,27 +685,29 @@ function renoise.Views.CheckBox:remove_notifier(notifier) end
 
 ---Add index change notifier
 ---@param notifier fun(index: integer)
-function renoise.Views.add_notifier(notifier) end
+function renoise.Views.Switch:add_notifier(notifier) end
 
 ---Remove index change notifier
 ---@param notifier fun(index: integer)
-function renoise.Views.remove_notifier(notifier) end
-
+function renoise.Views.Switch:remove_notifier(notifier) end
 
 --------------------------------------------------------------------------------
+---## renoise.Views.Popup
+
+---@class renoise.Views.Popup
+renoise.Views.Popup = {}
+
+---### properties
+
 ---@see renoise.ViewBuilder.popup
 ---A drop-down menu which shows the currently selected value when closed.
 ---When clicked, it pops up a list of all available items.
----
----. +--------------++---+
----. | Current Item || ^ |
----. +--------------++---+
----
----![Popup](___REPLACE_URL___/Popup.png)
+---```md
+--- +--------------++---+
+--- | Current Item || ^ |
+--- +--------------++---+
+---```
 ---@class renoise.Views.Popup : renoise.Views.Control
---------------------------------------------------------------------------------
----
----### properties
 ---
 ---Get/set the currently shown items. Item list can be empty, then "None" is
 ---displayed and the value won't change.
@@ -665,7 +717,7 @@ function renoise.Views.remove_notifier(notifier) end
 ---@field value integer
 ---
 ---Valid in the construction table only: Set up a value notifier.
----@field notifier fun(index : integer)
+---@field notifier fun(index: integer)
 ---
 ---Valid in the construction table only: Bind the view's value to a
 ---renoise.Document.ObservableNumber object. Will change the Observable
@@ -685,21 +737,23 @@ function renoise.Views.Popup:add_notifier(notifier) end
 ---@param notifier fun(index : integer)
 function renoise.Views.Popup:remove_notifier(notifier) end
 
-
 --------------------------------------------------------------------------------
+---## renoise.Views.Chooser
+
+---@class renoise.Views.Chooser
+renoise.Views.Chooser = {}
+
+---### properties
+
 ---@see renoise.ViewBuilder.chooser
 ---A radio button like set of vertically stacked items. Only one value can be
 ---selected at a time.
----
----. . Item A
----. o Item B
----. . Item C
----
----![Chooser](___REPLACE_URL___/Chooser.png)
+---```md
+--- . Item A
+--- o Item B
+--- . Item C
+---```
 ---@class renoise.Views.Chooser : renoise.Views.Control
---------------------------------------------------------------------------------
----
----### properties
 ---
 ---Get/set the currently shown items. Item list size must be >= 2.
 ---@field items string[]
@@ -729,19 +783,22 @@ function renoise.Views.Chooser:add_notifier(notifier) end
 function renoise.Views.Chooser:remove_notifier(notifier) end
 
 --------------------------------------------------------------------------------
+---## renoise.Views.ValueBox
+
+---@class renoise.Views.ValueBox
+renoise.Views.ValueBox = {}
+
+---### properties
+
 ---@see renoise.ViewBuilder.valuebox
 ---A box with arrow buttons and a text field that can be edited by the user.
 ---Allows showing and editing natural numbers in a custom range.
----
----. +---+-------+
----. |<|>|  12   |
----. +---+-------+
----
----![ValueBox](___REPLACE_URL___/ValueBox.png)
+---```md
+--- +---+-------+
+--- |<|>|  12   |
+--- +---+-------+
+---```
 ---@class renoise.Views.ValueBox : renoise.Views.Control
---------------------------------------------------------------------------------
----
----### properties
 ---
 ---Get/set the min value that is expected, allowed.
 ---@field min number Default: 0
@@ -795,22 +852,24 @@ function renoise.Views.ValueBox:add_notifier(notifier) end
 ---@param notifier fun(value : number)
 function renoise.Views.ValueBox:remove_notifier(notifier) end
 
-
 --------------------------------------------------------------------------------
+---## renoise.Views.Value
+
+---@class renoise.Views.Value
+renoise.Views.Value = {}
+
+---### properties
+
 ---@see renoise.ViewBuilder.value
 ---A static text view. Shows a string representation of a number and
 ---allows custom "number to string" conversion.
 ---@see renoise.Views.ValueField for a value text field that can be edited by the user.
----
----. +---+-------+
----. | 12.1 dB   |
----. +---+-------+
----
----![Value](___REPLACE_URL___/Value.png)
+---```md
+--- +---+-------+
+--- | 12.1 dB   |
+--- +---+-------+
+---```
 ---@class renoise.Views.Value : renoise.Views.View
---------------------------------------------------------------------------------
----
----### properties
 ---
 ---Get/set the current value.
 ---@field value number
@@ -849,21 +908,24 @@ function renoise.Views.Value:add_notifier(notifier) end
 ---@param notifier fun(value : number)
 function renoise.Views.Value:remove_notifier(notifier) end
 
-
 --------------------------------------------------------------------------------
+---## renoise.Views.ValueField
+
+---@class renoise.Views.ValueField
+renoise.Views.ValueField = {}
+
+---### properties
+
 ---@see renoise.ViewBuilder.valuefield
 ---A text view, which shows a string representation of a number and allows
 ---custom "number to string" conversion. The value's text can be edited by the
 ---user.
----. +---+-------+
----. | 12.1 dB   |
----. +---+-------+
----
----![ValueField](___REPLACE_URL___/ValueField.png)
+---```lua
+--- +---+-------+
+--- | 12.1 dB   |
+--- +---+-------+
+---```
 ---@class renoise.Views.ValueField : renoise.Views.Control
---------------------------------------------------------------------------------
----
----### properties
 ---
 ---Get/set the min value that is expected, allowed.
 ---@field min number Default: 0.0
@@ -915,22 +977,24 @@ function renoise.Views.ValueField:add_notifier(notifier) end
 ---@param notifier fun(value : number)
 function renoise.Views.ValueField:remove_notifier(notifier) end
 
-
 --------------------------------------------------------------------------------
+---## renoise.Views.Slider
+
+---@class renoise.Views.Slider
+renoise.Views.Slider = {}
+
+---### properties
+
 ---@see renoise.ViewBuilder.slider
 ---A slider with arrow buttons, which shows and allows editing of values in a
 ---custom range. A slider can be horizontal or vertical; will flip its
 ---orientation according to the set width and height. By default horizontal.
----
----. +---+---------------+
----. |<|>| --------[]    |
----. +---+---------------+
----
----![Slider](___REPLACE_URL___/Slider.png)
+---```md
+--- +---+---------------+
+--- |<|>| --------[]    |
+--- +---+---------------+
+---```
 ---@class renoise.Views.Slider : renoise.Views.Control
---------------------------------------------------------------------------------
----
----### properties
 ---
 ---Get/set the min value that is expected, allowed.
 ---@field min number Default: 0.0
@@ -970,20 +1034,22 @@ function renoise.Views.Slider:add_notifier(notifier) end
 ---@param notifier fun(value : number)
 function renoise.Views.Slider:remove_notifier(notifier) end
 
-
 --------------------------------------------------------------------------------
+---## renoise.Views.MiniSlider
+
+---@class renoise.Views.MiniSlider
+renoise.Views.MiniSlider = {}
+
+---### properties
+
 ---@see renoise.ViewBuilder.minislider
 ---Same as a slider, but without arrow buttons and a really tiny height. Just
 ---like the slider, a mini slider can be horizontal or vertical. It will flip
 ---its orientation according to the set width and height. By default horizontal.
----
----. --------[]
----
----![MiniSlider](___REPLACE_URL___/MiniSlider.png)
+---```md
+--- --------[]
+---```
 ---@class renoise.Views.MiniSlider : renoise.Views.Control
---------------------------------------------------------------------------------
----
----### properties
 ---
 ---Get/set the min value that is expected, allowed.
 ---@field min number Default: 0.0
@@ -1011,31 +1077,34 @@ function renoise.Views.Slider:remove_notifier(notifier) end
 ---### functions
 
 ---Add value change notifier
----@param notifier fun(value : number)
+---@param notifier fun(value: number)
 function renoise.Views.MiniSlider:add_notifier(notifier) end
 
 ---Remove value change notifier
----@param notifier fun(value : number)
+---@param notifier fun(value: number)
 function renoise.Views.MiniSlider:remove_notifier(notifier) end
 
 --------------------------------------------------------------------------------
+---## renoise.Views.RotaryEncoder
+
+---@class renoise.Views.RotaryEncoder
+renoise.Views.RotaryEncoder = {}
+
+---### properties
+
 ---@see renoise.ViewBuilder.rotary
 ---A slider which looks like a potentiometer.
 ---Note: when changing the size, the minimum of either width or height will be
 ---used to draw and control the rotary, therefor you should always set both
 ---equally when possible.
----
----.   +-+
----. / \   \
----.|   o   |
----. \  |  /
----.   +-+
----
----![RotaryEncoder](___REPLACE_URL___/RotaryEncoder.png)
+---```md
+---    +-+
+---  / \   \
+--- |   o   |
+---  \  |  /
+---    +-+
+---```
 ---@class renoise.Views.RotaryEncoder : renoise.Views.Control
---------------------------------------------------------------------------------
----
----### properties
 ---
 ---Get/set the min value that is expected, allowed.
 ---@field min number Default: 0.0
@@ -1071,6 +1140,13 @@ function renoise.Views.RotaryEncoder:add_notifier(notifier) end
 function renoise.Views.RotaryEncoder:remove_notifier(notifier) end
 
 --------------------------------------------------------------------------------
+---## renoise.Views.XYPad
+
+---@class renoise.Views.XYPad
+renoise.Views.XYPad = {}
+
+---### properties
+
 ---@see renoise.ViewBuilder.xypad
 ---A slider like pad which allows for controlling two values at once. By default
 ---it freely moves the XY values, but it can also be configured to snap back to
@@ -1079,18 +1155,15 @@ function renoise.Views.RotaryEncoder:remove_notifier(notifier) end
 ---All values, notifiers, current value or min/max properties will act just
 ---like a slider or a rotary's properties, but nstead of a single number, a
 ---table with the fields `{x = xvalue, y = yvalue}` is expected, returned.
----
----. +-------+
----. |    o  |
----. |   +   |
----. |       |
----. +-------+
----
----![XYPad](___REPLACE_URL___/XYPad.png)
+---```md
+--- +-------+
+--- |    o  |
+--- |   +   |
+--- |       |
+--- +-------+
+---```
 ---@class renoise.Views.XYPad : renoise.Views.Control
---------------------------------------------------------------------------------
 ---
----### properties
 ---@class XYPadValues
 ---@field x number
 ---@field y number
@@ -1136,36 +1209,33 @@ function renoise.Views.XYPad:add_notifier(notifier) end
 ---@param notifier fun(values : XYPadValues)
 function renoise.Views.XYPad:remove_notifier(notifier) end
 
---==============================================================================
----Dialogs can not created with the viewbuilder, but only by the application.
---TODO See "create custom views" on top of this file how to do so.
----@see renoise.Application.show_custom_dialog
----@class renoise.Dialog
---==============================================================================
----
+--------------------------------------------------------------------------------
+---## renoise.ViewBuilder
+
+---@class renoise.ViewBuilder
+renoise.ViewBuilder = {}
+
+---### constants
+
+---Default sizes for views and view layouts. Should be used instead of magic
+---numbers, also useful to inherit global changes from the main app.
+renoise.ViewBuilder.DEFAULT_CONTROL_MARGIN = 4
+renoise.ViewBuilder.DEFAULT_CONTROL_SPACING = 2
+renoise.ViewBuilder.DEFAULT_CONTROL_HEIGHT = 18
+renoise.ViewBuilder.DEFAULT_MINI_CONTROL_HEIGHT = 14
+renoise.ViewBuilder.DEFAULT_DIALOG_MARGIN = 8
+renoise.ViewBuilder.DEFAULT_DIALOG_SPACING = 8
+renoise.ViewBuilder.DEFAULT_DIALOG_BUTTON_HEIGHT = 22
+
 ---### properties
----
----**READ-ONLY**
----Check if a dialog is alive and visible.
----@field visible boolean
 
----### functions
-
----Bring an already visible dialog to front and make it the key window.
-function renoise.Dialog:show() end
-
----Close a visible dialog.
-function renoise.Dialog:close() end
-
-
---==============================================================================
 ---Class which is used to construct new views. All view properties, as listed
 ---above, can optionally be in-lined in a passed construction table:
----
----     local vb = renoise.ViewBuilder() -- create a new ViewBuilder
----     vb:button { text = "ButtonText" } -- is the same as
----     my_button = vb:button(); my_button.text = "ButtonText"
----
+---```lua
+---local vb = renoise.ViewBuilder() -- create a new ViewBuilder
+---vb:button { text = "ButtonText" } -- is the same as
+---my_button = vb:button(); my_button.text = "ButtonText"
+---```
 ---Besides the listed class properties, you can also specify the following
 ---"extra" properties in the passed table:
 ---
@@ -1186,200 +1256,143 @@ function renoise.Dialog:close() end
 ---
 ---* Nested child views: Add a child view to the currently specified view.
 ---  For example:
----
----         vb:column {
----            margin = 1,
----            vb:text {
----              text = "Text1"
----            },
----            vb:text {
----              text = "Text1"
----            }
----         }
----
+---```lua
+---vb:column {
+---   margin = 1,
+---   vb:text {
+---     text = "Text1"
+---   },
+---   vb:text {
+---     text = "Text1"
+---   }
+---}
+---```
 ---Creates a column view with `margin = 1` and adds two text views to the column.
 ---@class renoise.ViewBuilder
 ---
----### properties
----
 ---Table of views, which got registered via the "id" property
 ---View id is the table key, the table's value is the view's object.
----> e.g.: vb:text{ id="my_view", text="some_text"}  
----> vb.views.my_view.visible = false _(or)_  
----> vb.views["my_view"].visible = false
+---
+---### example
+---```lua
+---vb:text{ id="my_view", text="some_text"}
+---vb.views.my_view.visible = false _(or)_
+---vb.views["my_view"].visible = false
+---```
 ---@field views table<string, renoise.Views.View>
-renoise.ViewBuilder = {}
---==============================================================================
----
----### constants
----
----Default sizes for views and view layouts. Should be used instead of magic
----numbers, also useful to inherit global changes from the main app.
----
-renoise.ViewBuilder.DEFAULT_CONTROL_MARGIN = 4
-renoise.ViewBuilder.DEFAULT_CONTROL_SPACING = 2
-renoise.ViewBuilder.DEFAULT_CONTROL_HEIGHT = 18
-renoise.ViewBuilder.DEFAULT_MINI_CONTROL_HEIGHT = 14
-renoise.ViewBuilder.DEFAULT_DIALOG_MARGIN = 8
-renoise.ViewBuilder.DEFAULT_DIALOG_SPACING = 8
-renoise.ViewBuilder.DEFAULT_DIALOG_BUTTON_HEIGHT = 22
 
 ---### functions
 
+---Construct a new viewbuilder instance.
 ---@return renoise.ViewBuilder
 function renoise.ViewBuilder() end
 
---TODO separate properties objects for all?
-
 ---{ Rack Properties and/or child views }
----@param properties renoise.Views.Rack
+---@param properties renoise.Views.Rack?
 ---@return renoise.Views.Rack rack
 function renoise.ViewBuilder:column(properties) end
 
 ---{ Rack Properties and/or child views }
----@param properties renoise.Views.Rack
+---@param properties renoise.Views.Rack?
 ---@return renoise.Views.Rack rack
 function renoise.ViewBuilder:row(properties) end
 
 ---{ Aligner Properties and/or child views }
----@param properties renoise.Views.Aligner
+---@param properties renoise.Views.Aligner?
 ---@return renoise.Views.Aligner aligner
 function renoise.ViewBuilder:horizontal_aligner(properties) end
 
 ---{ Aligner Properties and/or child views }
----@param properties renoise.Views.Aligner
+---@param properties renoise.Views.Aligner?
 ---@return renoise.Views.Aligner aligner
 function renoise.ViewBuilder:vertical_aligner(properties) end
 
 ---{ View Properties and/or child views }
----@param properties renoise.Views.View
+---@param properties renoise.Views.View?
 ---@return renoise.Views.View view
 function renoise.ViewBuilder:space(properties) end
 
 ---{ Text Properties }
----@param properties renoise.Views.Text
+---@param properties renoise.Views.Text?
 ---@return renoise.Views.Text text
 function renoise.ViewBuilder:text(properties) end
 
 ---{ MultiLineText Properties }
----@param properties renoise.Views.MultiLineText
+---@param properties renoise.Views.MultiLineText?
 ---@return renoise.Views.MultiLineText multilinetext
 function renoise.ViewBuilder:multiline_text(properties) end
 
 ---{ TextField Properties }
----@param properties renoise.Views.TextField
+---@param properties renoise.Views.TextField?
 ---@return renoise.Views.TextField textfield
 function renoise.ViewBuilder:textfield(properties) end
 
 ---{ MultiLineText Properties }
----@param properties renoise.Views.MultiLineTextField
+---@param properties renoise.Views.MultiLineTextField?
 ---@return renoise.Views.MultiLineTextField multilinetextfield
 function renoise.ViewBuilder:multiline_textfield(properties) end
 
 ---{ Bitmap Properties }
----@param properties renoise.Views.Bitmap
+---@param properties renoise.Views.Bitmap?
 ---@return renoise.Views.Bitmap bitmap
 function renoise.ViewBuilder:bitmap(properties) end
 
 ---{ Button Properties }
----@param properties renoise.Views.Button
+---@param properties renoise.Views.Button?
 ---@return renoise.Views.Button button
 function renoise.ViewBuilder:button(properties) end
 
 ---{ Rack Properties }
----@param properties renoise.Views.CheckBox
+---@param properties renoise.Views.CheckBox?
 ---@return renoise.Views.CheckBox checkbox
 function renoise.ViewBuilder:checkbox(properties) end
 
 ---{ Switch Properties }
----@param properties renoise.Views.Switch
+---@param properties renoise.Views.Switch?
 ---@return renoise.Views.Switch switch
 function renoise.ViewBuilder:switch(properties) end
 
 ---{ Popup Properties }
----@param properties renoise.Views.Popup
+---@param properties renoise.Views.Popup?
 ---@return renoise.Views.Popup popup
 function renoise.ViewBuilder:popup(properties) end
 
 ---{ Chooser Properties }
----@param properties renoise.Views.Chooser
+---@param properties renoise.Views.Chooser?
 ---@return renoise.Views.Chooser chooser
 function renoise.ViewBuilder:chooser(properties) end
 
 ---{ ValueBox Properties }
----@param properties renoise.Views.ValueBox
+---@param properties renoise.Views.ValueBox?
 ---@return renoise.Views.ValueBox valuebox
 function renoise.ViewBuilder:valuebox(properties) end
 
 ---{ Value Properties }
----@param properties renoise.Views.Value
+---@param properties renoise.Views.Value?
 ---@return renoise.Views.Value value
 function renoise.ViewBuilder:value(properties) end
 
 ---{ ValueField Properties }
----@param properties renoise.Views.ValueField
+---@param properties renoise.Views.ValueField?
 ---@return renoise.Views.ValueField valuefield
 function renoise.ViewBuilder:valuefield(properties) end
 
 ---{ Slider Properties }
----@param properties renoise.Views.Slider
+---@param properties renoise.Views.Slider?
 ---@return renoise.Views.Slider slider
 function renoise.ViewBuilder:slider(properties) end
 
 ---{ MiniSlider Properties }
----@param properties renoise.Views.MiniSlider
+---@param properties renoise.Views.MiniSlider?
 ---@return renoise.Views.MiniSlider minislider
 function renoise.ViewBuilder:minislider(properties) end
 
 ---{ RotaryEncoder Properties }
----@param properties renoise.Views.RotaryEncoder
+---@param properties renoise.Views.RotaryEncoder?
 ---@return renoise.Views.RotaryEncoder rotaryencoder
 function renoise.ViewBuilder:rotary(properties) end
 
 ---{ XYPad Properties }
----@param properties renoise.Views.XYPad
+---@param properties renoise.Views.XYPad?
 ---@return renoise.Views.XYPad xypad
 function renoise.ViewBuilder:xypad(properties) end
-
----@class renoise.Views.View
-renoise.Views.View = {}
----@class renoise.Views.Control
-renoise.Views.Control = {}
----@class renoise.Views.Rack
-renoise.Views.Rack = {}
----@class renoise.Views.Aligner
-renoise.Views.Aligner = {}
----@class renoise.Views.Text
-renoise.Views.Text = {}
----@class renoise.Views.MultiLineText
-renoise.Views.MultiLineText = {}
----@class renoise.Views.TextField
-renoise.Views.TextField = {}
----@class renoise.Views.MultiLineTextField
-renoise.Views.MultiLineTextField = {}
----@class renoise.Views.Bitmap
-renoise.Views.Bitmap = {}
----@class renoise.Views.Button
-renoise.Views.Button = {}
----@class renoise.Views.CheckBox
-renoise.Views.CheckBox = {}
----@class renoise.Views.Switch
-renoise.Views.Switch = {}
----@class renoise.Views.Popup
-renoise.Views.Popup = {}
----@class renoise.Views.Chooser
-renoise.Views.Chooser = {}
----@class renoise.Views.ValueBox
-renoise.Views.ValueBox = {}
----@class renoise.Views.Value
-renoise.Views.Value = {}
----@class renoise.Views.ValueField
-renoise.Views.ValueField = {}
----@class renoise.Views.Slider
-renoise.Views.Slider = {}
----@class renoise.Views.MiniSlider
-renoise.Views.MiniSlider = {}
----@class renoise.Views.RotaryEncoder
-renoise.Views.RotaryEncoder = {}
----@class renoise.Views.XYPad
-renoise.Views.XYPad = {}

--- a/library/standard.lua
+++ b/library/standard.lua
@@ -1,13 +1,16 @@
 ---@meta
----Do not try to execute this file. It's just a type definition file.
+error("Do not try to execute this file. It's just a type definition file.")
 ---
----This is a reference for standard global and standard Lua API functions and
----tools that were added/changed within Renoise.
+---Please read the introduction at https://github.com/renoise/xrnx/
+---to get an overview about the complete API, and scripting for
+---Renoise in general...
 ---
+
+-------------------------------------------------------------------------------
+
 ---All standard Lua libraries are included in Renoise as well. You can find the
 ---full reference here: <http://www.lua.org/manual/5.1/manual.html#5>
 
--------------------------------------------------------------------------------
 ---## globals
 
 ---### added


### PR DESCRIPTION
- Unify file headers
- Use new Range: (f - t) everywhere
- Move consts to top of class definitions
- Move remaining TODOs to README