### PR TITLE
fixes for Document

### DIFF
--- a/library/renoise/document.lua
+++ b/library/renoise/document.lua
@@ -121,7 +121,7 @@ renoise.Document = {}
 ---my_other_document = renoise.Document.instantiate("MyDoc")
 ---```
 ---@param model_name string
----@return fun(properties: ObservableProperties):renoise.Document.DocumentNode
+---@return fun(properties: ObservableProperties):renoise.Document.DocumentNode<ObservableProperties>
 function renoise.Document.create(model_name)
     local new_node = renoise.Document.DocumentNode();
     return function(properties)
@@ -177,7 +177,7 @@ function renoise.Document.DocumentNode:property(property_name) end
 ---@overload fun(self, name: string, value: boolean): renoise.Document.ObservableBoolean
 ---@overload fun(self, name: string, value: number): renoise.Document.ObservableNumber
 ---@overload fun(self, name: string, value: string): renoise.Document.ObservableString
----@overload fun(self, name: string, value: boolean[]): renoise.Document.ObservableBoolean
+---@overload fun(self, name: string, value: boolean[]): renoise.Document.ObservableBooleanList
 ---@overload fun(self, name: string, value: number[]): renoise.Document.ObservableNumberList
 ---@overload fun(self, name: string, value: string[]): renoise.Document.ObservableStringList
 function renoise.Document.DocumentNode:add_property(name, value) end
@@ -261,9 +261,9 @@ function renoise.Document.DocumentList:find(start_pos, value) end
 ---Insert a new item to the end of the list when no position is specified, or
 ---at the specified position. Returns the newly created and inserted Observable.
 ---@param pos integer
----@param value boolean
+---@param value renoise.Document.DocumentNode
 ---@return renoise.Document.DocumentNode
----@overload fun(self, value: renoise.Document.DocumentNode):renoise.Document.ObservableBoolean
+---@overload fun(self, value: renoise.Document.DocumentNode):renoise.Document.DocumentNode
 function renoise.Document.DocumentList:insert(pos, value) end
 
 ---Removes an item (or the last one if no index is specified) from the list.
@@ -281,8 +281,8 @@ function renoise.Document.DocumentList:swap(pos1, pos2) end
 ---Checks if the given function, method was already registered as notifier.
 ---@param notifier ListNotifierFunction
 ---@returns boolean
----@overload fun(self, notifier: ListNotifierMethod1)
----@overload fun(self, notifier: ListNotifierMethod2)
+---@overload fun(self, notifier: ListNotifierMethod1):boolean
+---@overload fun(self, notifier: ListNotifierMethod2):boolean
 function renoise.Document.DocumentList:has_notifier(notifier) end
 
 ---Register a function or method as a notifier, which will be called as soon as

--- a/library/renoise/document.lua
+++ b/library/renoise/document.lua
@@ -121,7 +121,7 @@ renoise.Document = {}
 ---my_other_document = renoise.Document.instantiate("MyDoc")
 ---```
 ---@param model_name string
----@return fun(properties: ObservableProperties):renoise.Document.DocumentNode<ObservableProperties>
+---@return fun(properties: ObservableProperties):renoise.Document.DocumentNode
 function renoise.Document.create(model_name)
     local new_node = renoise.Document.DocumentNode();
     return function(properties)
@@ -143,7 +143,7 @@ function renoise.Document.instantiate(model_name) end
 
 ---A document node is a sub component in a document which contains other
 ---documents or observables.
----@class renoise.Document.DocumentNode
+---@class (exact) renoise.Document.DocumentNode : table
 ---Property access
 ---@operator index(any):DocumentMember?
 ---Construct a new document node.

--- a/library/renoise/document.lua
+++ b/library/renoise/document.lua
@@ -141,9 +141,13 @@ function renoise.Document.instantiate(model_name) end
 
 ---@alias DocumentMember renoise.Document.Observable|renoise.Document.ObservableList|renoise.Document.DocumentNode|renoise.Document.DocumentList
 
+-- TODO 
+-- inheriting from 'table' is workaround here to allow users to define custom types
+-- for their document classes and still have useful diagnostics instead of warnings
+
 ---A document node is a sub component in a document which contains other
 ---documents or observables.
----@class (exact) renoise.Document.DocumentNode : table
+---@class renoise.Document.DocumentNode : table
 ---Property access
 ---@operator index(any):DocumentMember?
 ---Construct a new document node.


### PR DESCRIPTION
Fixed a few types that were wrong in `document.lua`.

Also, before having the <ObservableProperties> template on line 124, user-defined preferences couldn't be annotated without warning from the LSP

For example

```lua

---@class MyPrefs : renoise.Document.DocumentNode
---@field my_string renoise.Document.ObservableString

---@type MyPrefs
prefs = renoise.Document.create("ScriptingToolPreferences")({ my_string = "abc" })
--^^^^ the LSP would complains here that DocumentNode couldn't be assigned to MyPrefs
```

Not sure how the fix works exactly since there is no "template typing" in other places where DocumentNode is defined but it makes the warning go away while still providing the same useful type hints later on.

