### PR TITLE
Fix song enum, optionals and comments

### DIFF
--- a/library/renoise/song.lua
+++ b/library/renoise/song.lua
@@ -131,14 +131,14 @@ renoise.Song = {
 ---@field tracks renoise.Track[]
 ---@field tracks_observable renoise.Document.ObservableList
 ---
----**READ-ONLY** Selected in the instrument box. Never nil.
+---**READ-ONLY** Selected in the instrument box.
 ---@field selected_instrument renoise.Instrument
 ---@field selected_instrument_observable renoise.Document.Observable
 ---@field selected_instrument_index integer
 ---@field selected_instrument_index_observable renoise.Document.Observable
 ---
 ---**READ-ONLY** Currently selected phrase the instrument's phrase map piano
----view. Can be nil.
+---view.
 ---@field selected_phrase renoise.InstrumentPhrase?
 ---@field selected_phrase_observable renoise.Document.Observable
 ---@field selected_phrase_index integer
@@ -149,28 +149,28 @@ renoise.Song = {
 ---@field selected_sample_observable renoise.Document.Observable
 ---@field selected_sample_index integer
 ---
----**READ-ONLY** Selected in the instrument's modulation view. Can be nil.
+---**READ-ONLY** Selected in the instrument's modulation view.
 ---@field selected_sample_modulation_set renoise.SampleModulationSet?
 ---@field selected_sample_modulation_set_observable renoise.Document.Observable
 ---@field selected_sample_modulation_set_index integer
 ---
----**READ-ONLY** Selected in the instrument's effects view. Can be nil.
+---**READ-ONLY** Selected in the instrument's effects view.
 ---@field selected_sample_device_chain renoise.SampleDeviceChain?
 ---@field selected_sample_device_chain_observable renoise.Document.Observable
 ---@field selected_sample_device_chain_index integer
 ---
----**READ-ONLY** Selected in the sample effect mixer. Can be nil.
+---**READ-ONLY** Selected in the sample effect mixer.
 ---@field selected_sample_device renoise.AudioDevice?
 ---@field selected_sample_device_observable renoise.Document.Observable
 ---@field selected_sample_device_index integer
 ---
----**READ-ONLY** Selected in the pattern editor or mixer. Never nil.
+---**READ-ONLY** Selected in the pattern editor or mixer.
 ---@field selected_track renoise.Track
 ---@field selected_track_observable renoise.Document.Observable
 ---@field selected_track_index integer
 ---@field selected_track_index_observable renoise.Document.Observable
 ---
----**READ-ONLY** Selected in the track DSP chain editor. Can be nil.
+---**READ-ONLY** Selected in the track DSP chain editor.
 ---@field selected_track_device renoise.AudioDevice?
 ---@field selected_track_device_observable renoise.Document.Observable
 ---@field selected_track_device_index integer
@@ -184,7 +184,7 @@ renoise.Song = {
 ---@field selected_parameter renoise.DeviceParameter?
 ---@field selected_parameter_observable renoise.Document.Observable
 ---
----Selected parameter in the automation editor. Can be nil.
+---Selected parameter in the automation editor.
 ---When setting a new parameter, parameter must be automateable and
 ---must be one of the currently selected track device chain.
 ---@field selected_automation_parameter renoise.DeviceParameter?
@@ -193,14 +193,14 @@ renoise.Song = {
 ---@field selected_automation_device renoise.AudioDevice?
 ---@field selected_automation_device_observable renoise.Document.Observable
 ---
----**READ-ONLY** The currently edited pattern. Never nil.
+---**READ-ONLY** The currently edited pattern.
 ---@field selected_pattern renoise.Pattern
 ---@field selected_pattern_observable renoise.Document.Observable
 ---**READ-ONLY** The currently edited pattern index.
 ---@field selected_pattern_index integer
 ---@field selected_pattern_index_observable renoise.Document.Observable
 ---
----**READ-ONLY** The currently edited pattern track object. Never nil.
+---**READ-ONLY** The currently edited pattern track object.
 ---and selected_track_observable for notifications.
 ---@field selected_pattern_track renoise.PatternTrack
 ---@field selected_pattern_track_observable renoise.Document.Observable

--- a/library/renoise/song.lua
+++ b/library/renoise/song.lua
@@ -59,8 +59,8 @@ renoise.Song = {
   SUB_COLUMN_DELAY = 5,
   SUB_COLUMN_SAMPLE_EFFECT_NUMBER = 6,
   SUB_COLUMN_SAMPLE_EFFECT_AMOUNT = 7,
-  SUB_COLUMN_EFFECT_NUMBER = 1,
-  SUB_COLUMN_EFFECT_AMOUNT = 2
+  SUB_COLUMN_EFFECT_NUMBER = 8,
+  SUB_COLUMN_EFFECT_AMOUNT = 9
 }
 
 ---### properties
@@ -102,20 +102,20 @@ renoise.Song = {
 ---Alternatively, write your own serializers for your custom data.
 ---@field tool_data string?
 ---
----**READ-ONLY** See renoise.Song:render(). Returns true while rendering is
----in progress.
+---**READ-ONLY** True while rendering is in progress.
+---@see renoise.Song.render
 ---@field rendering boolean
----**READ-ONLY** Range: (0.0 - 1.0) See renoise.Song:render(). 
----Returns the current render progress amount 
----@field rendering_progress number
+---**READ-ONLY** The current render progress amount 
+---@see renoise.Song.render
+---@field rendering_progress number Range: (0.0 - 1.0)
 ---
----**READ-ONLY** See renoise.Transport for more info.
+---**READ-ONLY**
 ---@field transport renoise.Transport
 ---
----**READ-ONLY** See renoise.PatternSequencer for more info.
+---**READ-ONLY**
 ---@field sequencer renoise.PatternSequencer
 ---
----**READ-ONLY** See renoise.PatternIterator for more info.
+---**READ-ONLY**
 ---@field pattern_iterator renoise.PatternIterator
 ---
 ---**READ-ONLY** number of normal playback tracks (non-master or sends) in song.
@@ -132,7 +132,7 @@ renoise.Song = {
 ---@field tracks_observable renoise.Document.ObservableList
 ---
 ---**READ-ONLY** Selected in the instrument box. Never nil.
----@field selected_instrument renoise.Instrument?
+---@field selected_instrument renoise.Instrument
 ---@field selected_instrument_observable renoise.Document.Observable
 ---@field selected_instrument_index integer
 ---@field selected_instrument_index_observable renoise.Document.Observable
@@ -391,13 +391,13 @@ function renoise.Song:cancel_rendering() end
 ---by default the song end.
 ---@field end_pos renoise.SongPos?
 ---by default the players current rate.
----@field sample_rate 22050|44100|48000|88200|96000|192000?
+---@field sample_rate (22050|44100|48000|88200|96000|192000)?
 ---by default 32.
----@field bit_depth 16|24|32?
+---@field bit_depth (16|24|32)?
 ---by default "default".
----@field interpolation "default"|"precise"?
+---@field interpolation ("default"|"precise")?
 ---by default "high".
----@field priority "low"|"realtime"|"high"?
+---@field priority ("low"|"realtime"|"high")?
 
 ---Start rendering a section of the song or the whole song to a WAV file.
 ---

--- a/library/renoise/song/transport.lua
+++ b/library/renoise/song/transport.lua
@@ -105,7 +105,7 @@ renoise.Transport = {
 ---Metronome precount
 ---@field metronome_precount_enabled boolean
 ---@field metronome_precount_enabled_observable renoise.Document.Observable
----@field metronome_precount_bars integer Range: ([1 - 4)
+---@field metronome_precount_bars integer Range: (1 - 4)
 ---@field metronome_precount_bars_observable renoise.Document.Observable
 ---
 ---Quantize


### PR DESCRIPTION
* sub column enum was wrong in song.lua
* some optional unions needed parens
* selected_instrument was misrepresented as optional
* removed comments regarding nil as this info is now encoded in the types
* fixed a typo in transport.lua