### PR TITLE
fix return type for song:track()

### DIFF
--- a/library/renoise/song.lua
+++ b/library/renoise/song.lua
@@ -299,9 +299,12 @@ function renoise.Song:delete_track_at(index) end
 function renoise.Song:swap_tracks_at(index1, index2) end
 
 ---Access to a single track by index. Use properties 'tracks' to iterate over
----all tracks and to query the track count.
+---all tracks and to query the track count.  
+---Before accessing GroupTrack-only properties,
+---you have to narrow down the type by using  
+---`type(track) == "renoise.GroupTrack"`
 ---@param index integer
----@return renoise.Track | renoise.GroupTrack
+---@return renoise.Track
 function renoise.Song:track(index) end
 
 ---Set the selected track to prev relative to the current track. Takes

--- a/library/renoise/song.lua
+++ b/library/renoise/song.lua
@@ -301,7 +301,7 @@ function renoise.Song:swap_tracks_at(index1, index2) end
 ---Access to a single track by index. Use properties 'tracks' to iterate over
 ---all tracks and to query the track count.
 ---@param index integer
----@return renoise.Track
+---@return renoise.Track | renoise.GroupTrack
 function renoise.Song:track(index) end
 
 ---Set the selected track to prev relative to the current track. Takes

--- a/library/renoise/song/track.lua
+++ b/library/renoise/song/track.lua
@@ -197,7 +197,7 @@ renoise.GroupTrack = {}
 ---
 ---**READ-ONLY** All member tracks of this group, including subgroups and
 ---their tracks.
----@field members (renoise.Track|renoise.GroupTrack)[]
+---@field members (renoise.Track | renoise.GroupTrack)[]
 ---
 ---Collapsed/expanded visual appearance of whole group.
 ---@field group_collapsed boolean

--- a/library/renoise/song/track.lua
+++ b/library/renoise/song/track.lua
@@ -196,8 +196,11 @@ renoise.GroupTrack = {}
 ---@class renoise.GroupTrack : renoise.Track
 ---
 ---**READ-ONLY** All member tracks of this group, including subgroups and
----their tracks.
----@field members (renoise.Track | renoise.GroupTrack)[]
+---their tracks.  
+---Before accessing GroupTrack-only properties on members
+---you have to narrow down their type by using  
+---`type(member_track) == "renoise.GroupTrack"`
+---@field members renoise.Track[]
 ---
 ---Collapsed/expanded visual appearance of whole group.
 ---@field group_collapsed boolean


### PR DESCRIPTION
Song:track() can return either a Track or a GroupTrack, otherwise the lsp can complain for accessing `members` and `group_collapsed`. Would be nice to be able to force a check for the type like with optionals, but I'm not sure that's possible.