### PR TITLE
Adding example for DocumentList

### DIFF
--- a/library/renoise/document.lua
+++ b/library/renoise/document.lua
@@ -241,34 +241,28 @@ function renoise.Document.DocumentNode:from_string(string) end
 ----- our goal here is to have a document that contains a list of documents
 ----- which can loaded as preferences for our tool
 -----
------ define a class for our complex type for document items in the list
------ so that Renoise knows how to load it later
------ our entries will have
----class "Entry" (renoise.Document.DocumentNode)
+----- define a class model for our complex type for document items in the list
+----- so that Renoise knows how to load it later our entries will have
+---renoise.Document.create("Entry") {
+---  name = renoise.Document.ObservableString(),
+---  path = renoise.Document.ObservableString(),
+---}
 ---
------ implement a constructor that adds two string properties
----function Entry:__init()
----  renoise.Document.DocumentNode.__init(self)
----  self:add_properties({
----    name = "",
----    path = ""
----  })
----end
----
------ a helper function to create new instances with data
+----- create new entry instances with the given data
 ---function create_entry(name, path)
----  local entry = Entry()
+---  local entry = renoise.Document.instantiate("Entry")
 ---  entry.name.value = name
 ---  entry.path.value = path
 ---  return entry
 ---end
 ---
------ create our main document with a DocumentList element to hold entries
----preferences = renoise.Document.create("MyPreferences") {
+----- define a class model for our preferences which is using a list of entries
+---renoise.Document.create("MyPreferences") {
 ---  list = renoise.Document.DocumentList()
 ---}
 ---
------ assign it to our tool
+----- assign a fresh instance of our main document as preferences
+---local preferences = renoise.Document.instantiate("MyPreferences")
 ---renoise.tool().preferences = preferences
 ---
 ----- insert elements into the list using :insert(index, element)

--- a/library/renoise/document.lua
+++ b/library/renoise/document.lua
@@ -235,6 +235,62 @@ function renoise.Document.DocumentNode:from_string(string) end
 
 ---A document list is a document sub component which may contain other document
 ---nodes in an observable list.
+---
+---### example:
+---```lua
+----- our goal here is to have a document that contains a list of documents
+----- which can loaded as preferences for our tool
+-----
+----- define a class for our complex type for document items in the list
+----- so that Renoise knows how to load it later
+----- our entries will have
+---class "Entry" (renoise.Document.DocumentNode)
+---
+----- implement a constructor that adds two string properties
+---function Entry:__init()
+---  renoise.Document.DocumentNode.__init(self)
+---  self:add_properties({
+---    name = "",
+---    path = ""
+---  })
+---end
+---
+----- a helper function to create new instances with data
+---function create_entry(name, path)
+---  local entry = Entry()
+---  entry.name.value = name
+---  entry.path.value = path
+---  return entry
+---end
+---
+----- create our main document with a DocumentList element to hold entries
+---preferences = renoise.Document.create("MyPreferences") {
+---  list = renoise.Document.DocumentList()
+---}
+---
+----- assign it to our tool
+---renoise.tool().preferences = preferences
+---
+----- insert elements into the list using :insert(index, element)
+----- we call our helper to create an instance of Entry
+---preferences.list:insert(1, create_entry("some name", "some/path"))
+---
+----- access entries by using :property(index)
+---print(preferences.list:property(1).name)
+---
+----- get the size of the list (you can use :size() as well)
+---print(#preferences.list)
+---
+----- loop over the list to print all entries
+---for i = 1, #preferences.list do
+---  local entry = preferences.list:property(i)
+---  print(i)
+---  print(entry.name)
+---  print(entry.path)
+---end
+---
+----- try reloading your tool to see the list get bigger
+---```
 ---@class renoise.Document.DocumentList
 ---Query a list's size (item count).
 ---@operator len():integer

--- a/library/renoise/document/observable.lua
+++ b/library/renoise/document/observable.lua
@@ -288,7 +288,7 @@ function renoise.Document.ObservableNumberList:swap(pos1, pos2) end
 --------------------------------------------------------------------------------
 ---## renoise.Document.ObservableStringList
 
----A observable list of number values.
+---A observable list of string values.
 ---@class renoise.Document.ObservableStringList : renoise.Document.ObservableList, renoise.Document.Serializable
 ---Query a list's size (item count).
 ---@operator len:integer


### PR DESCRIPTION
A case came up on the discord where there would be a need to use the DocumentList, and it took a bit of time to get how to work with it in tandem with tool preferences so that Renoise would correctly load each item.

I've created an example from the solution and added it to the DocumentList definition.

Maybe this example would be better in the guide? Personally, I'd like having it here from a search standpoint, as this would be the first place I'd look for details on the DocumentList.

Also, I couldn't figure out how to supply constructor arguments to the custom `Entry` class here *while* also having Renoise be able to deserialize the document from disk using it, maybe there is a cleaner way than this `create_entry` helper?

I also found a type-typo on the ObservableStringList hint.